### PR TITLE
Functions with *args or **kwargs are not supported as tools

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -90,7 +90,7 @@ async def get_entity(entity_id: str, fields: Optional[List[str]] = None, detaile
 
 @mcp.tool()
 @async_handler("entity_action")
-async def entity_action(entity_id: str, action: str, params: Optional[Dict[str, Any]]) -> dict:
+async def entity_action(entity_id: str, action: str, params: Optional[Dict[str, Any]] = None) -> dict:
     """
     Perform an action on a Home Assistant entity (on, off, toggle)
     
@@ -123,7 +123,7 @@ async def entity_action(entity_id: str, action: str, params: Optional[Dict[str, 
     domain = entity_id.split(".")[0]
     
     # Prepare service data
-    data = {"entity_id": entity_id, **params}
+    data = {"entity_id": entity_id, **(params or {})}
     
     logger.info(f"Performing action '{action}' on entity: {entity_id} with params: {params}")
     return await call_service(domain, service, data)


### PR DESCRIPTION
When using the `entity_action` tool, the Model trying to supply "params" as another argument. This leads to a 400 error when trying to make a request to home assistant. The agent doesn't understand that params can be a variable list of key words. Something with the schema is confusing it.

Upon further inspection, it seems like [FastMCP doesn't support kwargs for tools:](https://gofastmcp.com/servers/tools)

> Functions with *args or **kwargs are not supported as tools. This restriction exists because FastMCP needs to generate a complete parameter schema for the MCP protocol, which isn’t possible with variable argument lists.

Updated the entity_action so that it takes a dictionary instead. This solves the issue on tool calling and doesn't produce 400 error. 