### PR TITLE
support custom TLS cert store

### DIFF
--- a/app/hass.py
+++ b/app/hass.py
@@ -90,8 +90,12 @@ async def get_client() -> httpx.AsyncClient:
     """Get a persistent httpx client for Home Assistant API calls"""
     global _client
     if _client is None:
-        logger.debug("Creating new HTTP client")
-        _client = httpx.AsyncClient(timeout=10.0)
+        ca_bundle = os.getenv("REQUESTS_CA_BUNDLE") or os.getenv("SSL_CERT_FILE")
+        logger.debug("Creating new HTTP client with CA bundle: %s", ca_bundle or "default truststore")
+        _client = httpx.AsyncClient(
+            timeout=10.0,
+            verify=ca_bundle if ca_bundle else True,
+        )
     return _client
 
 async def cleanup_client() -> None:


### PR DESCRIPTION
I run my inhouse CA and HomeAssistant has its own valid certificate and runs on 443/https. Hence I needed a way to inject my trust store into `httpx`. I've used the most common shell variables used for `requests` and `openssl`.
