### PR TITLE
Fix FastMCP initialization - remove unsupported capabilities parameter

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -28,11 +28,7 @@ T = TypeVar('T')
 from mcp.server.fastmcp import FastMCP, Context, Image
 from mcp.server.stdio import stdio_server
 import mcp.types as types
-mcp = FastMCP("Hass-MCP", capabilities={
-    "resources": {},
-    "tools": {},
-    "prompts": {}
-})
+mcp = FastMCP("Hass-MCP")
 
 def async_handler(command_type: str):
     """


### PR DESCRIPTION
## Problem
The current code fails with `TypeError: FastMCP.__init__() got an unexpected keyword argument 'capabilities'` when using recent versions of the MCP library.

## Solution
Removed the `capabilities` parameter from FastMCP initialization as it's no longer supported in the current MCP specification.

## Changes
- Updated `app/server.py` line 31 to use `FastMCP("Hass-MCP")` instead of `FastMCP("Hass-MCP", capabilities={...})`

## Testing
- Tested with uvx and Claude Desktop - server now starts successfully
- All MCP tools function correctly

This fixes the startup error and makes the package compatible with current MCP library versions.