### PR TITLE
Bump version to 0.1.1 for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hass-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Home Assistant Model Context Protocol (MCP) server"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- Updates version in pyproject.toml from 0.1.0 to 0.1.1
- Aligns package version with existing v0.1.1 git tag
- Fixes PyPI deployment issue caused by version mismatch

## Context
The v0.1.1 tag was already created but the version in pyproject.toml wasn't updated, preventing successful PyPI deployment.

## Test plan
- [x] Version updated in pyproject.toml
- [ ] PyPI deployment should succeed after merge