### PR TITLE
Add statistics API and date range queries for historical data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,3 +34,8 @@ CHANGELOG.md
 .idea/
 *.swp
 *.swo
+
+# Ignore CI/CD and lock files
+.github/
+uv.lock
+.pytest_cache/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_IMAGE: voska/hass-mcp
+  DOCKER_IMAGE: rmaher001/hass-mcp-plus
   PLATFORMS: linux/amd64,linux/arm64
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Thumbs.db
 
 # Testing
 .pytest_cache/
+
+# Development documentation
+DEVELOPMENT.md

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 
 # Development documentation
 DEVELOPMENT.md
+MCP_CONFIG_LOCATIONS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
 # MCP server Dockerfile for Claude Desktop integration
 FROM ghcr.io/astral-sh/uv:0.6.6-python3.13-bookworm
 
+# Create non-root user for security
+RUN groupadd -r mcp && useradd -r -g mcp mcp
+
 # Set working directory
 WORKDIR /app
 
-# Copy project files
-COPY . .
+# Copy only necessary files (see .dockerignore for exclusions)
+COPY pyproject.toml README.md LICENSE ./
+COPY app/ ./app/
 
 # Set environment for MCP communication
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
-# Install package with UV (using --system flag)
-RUN uv pip install --system -e .
+# Install package with UV (regular install, not editable)
+RUN uv pip install --system .
+
+# Change ownership and switch to non-root user
+RUN chown -R mcp:mcp /app
+USER mcp
 
 # Run the MCP server with stdio communication using the module directly
 ENTRYPOINT ["python", "-m", "app"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Matt Voska
+Copyright (c) 2025 Richard Maher
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Hass-MCP
+# Hass-MCP-Plus
 
-A Model Context Protocol (MCP) server for Home Assistant integration with Claude and other LLMs.
+An enhanced Model Context Protocol (MCP) server for Home Assistant integration with Claude and other LLMs, built on [voska/hass-mcp](https://github.com/voska/hass-mcp). Thanks to [Matt Voska](https://github.com/voska) for creating the original project.
 
-<a href="https://glama.ai/mcp/servers/@voska/hass-mcp">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@voska/hass-mcp/badge" alt="Hass-MCP MCP server" />
-</a>
+**What's new in Plus:**
+- Automation trace debugging (list and inspect execution traces)
+- Enhanced historical data tools (statistics with date ranges)
+- Improved token efficiency for LLM context management
+- WebSocket API for error log retrieval
 
 ## Overview
 
-Hass-MCP enables AI assistants like Claude to interact directly with your Home Assistant instance, allowing them to:
+Hass-MCP-Plus enables AI assistants like Claude to interact directly with your Home Assistant instance, allowing them to:
 
 - Query the state of devices and sensors
 - Control lights, switches, and other entities
@@ -17,20 +19,15 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 - Search for specific entities
 - Create guided conversations for common tasks
 
-## Screenshots
-
-<img width="700" alt="Screenshot 2025-03-16 at 15 48 01" src="https://github.com/user-attachments/assets/5f9773b4-6aef-4139-a978-8ec2cc8c0aea" />
-<img width="400" alt="Screenshot 2025-03-16 at 15 50 59" src="https://github.com/user-attachments/assets/17e1854a-9399-4e6d-92cf-cf223a93466e" />
-<img width="400" alt="Screenshot 2025-03-16 at 15 49 26" src="https://github.com/user-attachments/assets/4565f3cd-7e75-4472-985c-7841e1ad6ba8" />
-
 ## Features
 
 - **Entity Management**: Get states, control devices, and search for entities
 - **Domain Summaries**: Get high-level information about entity types
-- **Automation Support**: List and control automations
+- **Automation Support**: List automations and debug with execution traces
+- **Historical Data**: Query statistics and history with date range support
 - **Guided Conversations**: Use prompts for common tasks like creating automations
 - **Smart Search**: Find entities by name, type, or state
-- **Token Efficiency**: Lean JSON responses to minimize token usage
+- **Token Efficiency**: Lean JSON responses to minimize context usage
 
 ## Installation
 
@@ -48,7 +45,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 1. Pull the Docker image:
 
    ```bash
-   docker pull voska/hass-mcp:latest
+   docker pull rmaher001/hass-mcp-plus:latest
    ```
 
 2. Add the MCP server to Claude Desktop:
@@ -60,7 +57,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
    ```json
    {
      "mcpServers": {
-       "hass-mcp": {
+       "hass-mcp-plus": {
          "command": "docker",
          "args": [
            "run",
@@ -70,7 +67,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
            "HA_URL",
            "-e",
            "HA_TOKEN",
-           "voska/hass-mcp"
+           "rmaher001/hass-mcp-plus"
          ],
          "env": {
            "HA_URL": "http://homeassistant.local:8123",
@@ -89,7 +86,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 
    f. Save the file and restart Claude Desktop
 
-3. The "Hass-MCP" tool should now appear in your Claude Desktop tools menu
+3. The "Hass-MCP-Plus" tool should now appear in your Claude Desktop tools menu
 
 > **Note**: If you're running Home Assistant in Docker on the same machine, you may need to add `--network host` to the Docker args for the container to access Home Assistant. Alternatively, use the IP address of your machine instead of `host.docker.internal`.
 
@@ -106,9 +103,9 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
    ```json
    {
      "mcpServers": {
-       "hass-mcp": {
+       "hass-mcp-plus": {
          "command": "uvx",
-         "args": ["hass-mcp"],
+         "args": ["hass-mcp-plus"],
          "env": {
            "HA_URL": "http://homeassistant.local:8123",
            "HA_TOKEN": "YOUR_LONG_LIVED_TOKEN"
@@ -126,7 +123,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 
    f. Save the file and restart Claude Desktop
 
-3. The "Hass-MCP" tool should now appear in your Claude Desktop tools menu
+3. The "Hass-MCP-Plus" tool should now appear in your Claude Desktop tools menu
 
 ## Other MCP Clients
 
@@ -134,11 +131,11 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 
 1. Go to Cursor Settings > MCP > Add New MCP Server
 2. Fill in the form:
-   - Name: `Hass-MCP`
+   - Name: `Hass-MCP-Plus`
    - Type: `command`
    - Command:
      ```
-     docker run -i --rm -e HA_URL=http://homeassistant.local:8123 -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN voska/hass-mcp
+     docker run -i --rm -e HA_URL=http://homeassistant.local:8123 -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN rmaher001/hass-mcp-plus
      ```
    - Replace `YOUR_LONG_LIVED_TOKEN` with your actual Home Assistant token
    - Update the HA_URL to match your Home Assistant instance address
@@ -151,14 +148,14 @@ To use with Claude Code CLI, you can add the MCP server directly using the `mcp 
 **Using Docker (recommended):**
 
 ```bash
-claude mcp add hass-mcp -e HA_URL=http://homeassistant.local:8123 -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN -- docker run -i --rm -e HA_URL -e HA_TOKEN voska/hass-mcp
+claude mcp add hass-mcp-plus -e HA_URL=http://homeassistant.local:8123 -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN -- docker run -i --rm -e HA_URL -e HA_TOKEN rmaher001/hass-mcp-plus
 ```
 
 Replace `YOUR_LONG_LIVED_TOKEN` with your actual Home Assistant token and update the HA_URL to match your Home Assistant instance address.
 
 ## Usage Examples
 
-Here are some examples of prompts you can use with Claude once Hass-MCP is set up:
+Here are some examples of prompts you can use with Claude once Hass-MCP-Plus is set up:
 
 - "What's the current state of my living room lights?"
 - "Turn off all the lights in the kitchen"
@@ -170,23 +167,36 @@ Here are some examples of prompts you can use with Claude once Hass-MCP is set u
 
 ## Available Tools
 
-Hass-MCP provides several tools for interacting with Home Assistant:
+Hass-MCP-Plus provides several tools for interacting with Home Assistant:
 
-- `get_version`: Get the Home Assistant version
+### Entity Management
 - `get_entity`: Get the state of a specific entity with optional field filtering
 - `entity_action`: Perform actions on entities (turn on, off, toggle)
 - `list_entities`: Get a list of entities with optional domain filtering and search
 - `search_entities_tool`: Search for entities matching a query
 - `domain_summary_tool`: Get a summary of a domain's entities
+- `system_overview`: Get a comprehensive overview of the entire Home Assistant system
+
+### Automation & Debugging
 - `list_automations`: Get a list of all automations
+- `list_automation_traces`: Get recent execution traces for a specific automation
+- `get_automation_trace`: Get detailed trace for a specific automation run
+- `get_error_log`: Get the Home Assistant error log
+
+### Historical Data
+- `get_history`: Get raw state history of an entity
+- `get_history_range`: Get state history for a specific date/time range
+- `get_statistics`: Get aggregated statistics (mean, min, max) for an entity
+- `get_statistics_range`: Get statistics for a specific date/time range
+
+### System
+- `get_version`: Get the Home Assistant version
 - `call_service_tool`: Call any Home Assistant service
 - `restart_ha`: Restart Home Assistant
-- `get_history`: Get the state history of an entity
-- `get_error_log`: Get the Home Assistant error log
 
 ## Prompts for Guided Conversations
 
-Hass-MCP includes several prompts for guided conversations:
+Hass-MCP-Plus includes several prompts for guided conversations:
 
 - `create_automation`: Guide for creating Home Assistant automations based on trigger type
 - `debug_automation`: Troubleshooting help for automations that aren't working
@@ -198,7 +208,7 @@ Hass-MCP includes several prompts for guided conversations:
 
 ## Available Resources
 
-Hass-MCP provides the following resource endpoints:
+Hass-MCP-Plus provides the following resource endpoints:
 
 - `hass://entities/{entity_id}`: Get the state of a specific entity
 - `hass://entities/{entity_id}/detailed`: Get detailed information about an entity with all attributes

--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,64 @@
 import os
-from typing import Optional
+import logging
+from urllib.parse import urlparse
 
-# Home Assistant configuration
-HA_URL: str = os.environ.get("HA_URL", "http://localhost:8123")
-HA_TOKEN: str = os.environ.get("HA_TOKEN", "")
+logger = logging.getLogger(__name__)
+
+# Placeholder tokens that indicate user hasn't configured properly
+_PLACEHOLDER_TOKENS = [
+    "YOUR_TOKEN",
+    "YOUR_LONG_LIVED_TOKEN",
+    "your_token",
+    "your_long_lived_token",
+    "mock_token",
+    "test_token",
+    "<token>",
+    "TOKEN_HERE",
+]
+
+
+def _validate_ha_url(url: str) -> str:
+    """Validate Home Assistant URL format and log warnings."""
+    if not url:
+        logger.warning("HA_URL is empty, using default http://localhost:8123")
+        return "http://localhost:8123"
+
+    parsed = urlparse(url)
+
+    # Check for valid scheme
+    if parsed.scheme not in ("http", "https"):
+        logger.warning(f"HA_URL has invalid scheme '{parsed.scheme}', expected http or https")
+
+    # Check for hostname
+    if not parsed.netloc:
+        logger.warning(f"HA_URL '{url}' appears to be missing hostname")
+
+    return url
+
+
+def _validate_ha_token(token: str) -> str:
+    """Validate Home Assistant token and log warnings for common issues."""
+    if not token:
+        logger.warning("HA_TOKEN is not set. API calls will fail without authentication.")
+        return token
+
+    # Check for placeholder tokens
+    if token in _PLACEHOLDER_TOKENS:
+        logger.warning(
+            f"HA_TOKEN appears to be a placeholder value. "
+            "Please set a valid Home Assistant Long-Lived Access Token."
+        )
+
+    # Basic sanity check - HA tokens are typically long
+    if len(token) < 100:
+        logger.debug("HA_TOKEN is shorter than typical HA tokens (usually 100+ chars)")
+
+    return token
+
+
+# Home Assistant configuration with validation
+HA_URL: str = _validate_ha_url(os.environ.get("HA_URL", "http://localhost:8123"))
+HA_TOKEN: str = _validate_ha_token(os.environ.get("HA_TOKEN", ""))
 
 def get_ha_headers() -> dict:
     """Return the headers needed for Home Assistant API requests"""

--- a/app/hass.py
+++ b/app/hass.py
@@ -513,62 +513,54 @@ async def restart_home_assistant() -> Dict[str, Any]:
 @handle_api_errors
 async def get_hass_error_log() -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting using WebSocket API
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
+        - records: List of error/warning log records
         - error_count: Number of ERROR entries found
         - warning_count: Number of WARNING entries found
         - integration_mentions: Map of integration names to mention counts
         - error: Error message if retrieval failed
     """
     try:
-        # Call the Home Assistant API error_log endpoint
-        url = f"{HA_URL}/api/error_log"
-        headers = get_ha_headers()
-        
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, headers=headers, timeout=30)
-            
-            if response.status_code == 200:
-                log_text = response.text
-                
-                # Count errors and warnings
-                error_count = log_text.count("ERROR")
-                warning_count = log_text.count("WARNING")
-                
-                # Extract integration mentions
-                import re
-                integration_mentions = {}
-                
-                # Look for patterns like [mqtt], [zwave], etc.
-                for match in re.finditer(r'\[([a-zA-Z0-9_]+)\]', log_text):
-                    integration = match.group(1).lower()
-                    if integration not in integration_mentions:
-                        integration_mentions[integration] = 0
-                    integration_mentions[integration] += 1
-                
-                return {
-                    "log_text": log_text,
-                    "error_count": error_count,
-                    "warning_count": warning_count,
-                    "integration_mentions": integration_mentions
-                }
-            else:
-                return {
-                    "error": f"Error retrieving error log: {response.status_code} {response.reason_phrase}",
-                    "details": response.text,
-                    "log_text": "",
-                    "error_count": 0,
-                    "warning_count": 0,
-                    "integration_mentions": {}
-                }
+        # Use WebSocket API to retrieve system_log records
+        # call_websocket_api returns result["result"] directly
+        records = await call_websocket_api("system_log/list")
+
+        if not records or not isinstance(records, list):
+            return {
+                "error": "Failed to retrieve system log records",
+                "records": [],
+                "error_count": 0,
+                "warning_count": 0,
+                "integration_mentions": {}
+            }
+
+        # Count errors and warnings
+        error_count = sum(1 for r in records if r.get("level") == "ERROR")
+        warning_count = sum(1 for r in records if r.get("level") == "WARNING")
+
+        # Extract integration mentions from logger names
+        integration_mentions = {}
+        for record in records:
+            logger_name = record.get("name", "")
+            # Extract integration name from logger like "homeassistant.components.mqtt"
+            if "homeassistant.components." in logger_name:
+                integration = logger_name.split("homeassistant.components.")[1].split(".")[0]
+                integration_mentions[integration] = integration_mentions.get(integration, 0) + 1
+
+        return {
+            "records": records,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "integration_mentions": integration_mentions
+        }
     except Exception as e:
         logger.error(f"Error retrieving Home Assistant error log: {str(e)}")
         return {
             "error": f"Error retrieving error log: {str(e)}",
-            "log_text": "",
+            "records": [],
             "error_count": 0,
             "warning_count": 0,
             "integration_mentions": {}

--- a/app/hass.py
+++ b/app/hass.py
@@ -89,13 +89,20 @@ def handle_api_errors(func: F) -> F:
     
     return cast(F, wrapper)
 
-# Persistent HTTP client
+# Persistent HTTP client with granular timeout configuration
+_timeout_config = httpx.Timeout(
+    connect=5.0,    # Connection timeout - fail fast on unreachable hosts
+    read=30.0,      # Read timeout - allow time for long-running queries (stats, history)
+    write=5.0,      # Write timeout - service calls should be quick
+    pool=5.0        # Pool timeout - waiting for available connection
+)
+
 async def get_client() -> httpx.AsyncClient:
     """Get a persistent httpx client for Home Assistant API calls"""
     global _client
     if _client is None:
         logger.debug("Creating new HTTP client")
-        _client = httpx.AsyncClient(timeout=10.0)
+        _client = httpx.AsyncClient(timeout=_timeout_config)
     return _client
 
 async def cleanup_client() -> None:

--- a/app/hass.py
+++ b/app/hass.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 import json
 import asyncio
+import ssl
 import websockets
 
 from app.config import HA_URL, HA_TOKEN, get_ha_headers
@@ -128,8 +129,14 @@ async def call_websocket_api(message_type: str, **kwargs) -> Dict[str, Any]:
     ws_url = HA_URL.replace("http://", "ws://").replace("https://", "wss://")
     ws_url = f"{ws_url}/api/websocket"
 
+    # Use SSL context for secure WebSocket connections
+    ssl_context = None
+    if ws_url.startswith("wss://"):
+        ssl_context = ssl.create_default_context()
+        # Validates certificates by default - no need for explicit verify_mode
+
     try:
-        async with websockets.connect(ws_url) as websocket:
+        async with websockets.connect(ws_url, ssl=ssl_context) as websocket:
             # Wait for auth required message
             auth_msg = await websocket.recv()
             auth_data = json.loads(auth_msg)

--- a/app/hass.py
+++ b/app/hass.py
@@ -566,6 +566,148 @@ async def get_hass_error_log() -> Dict[str, Any]:
             "integration_mentions": {}
         }
 
+
+@handle_api_errors
+async def list_automation_traces(
+    automation_id: str,
+    domain: str = "automation",
+    limit: int = 10
+) -> Dict[str, Any]:
+    """
+    List recent execution traces for a specific automation.
+
+    Token-efficient: Returns only essential fields, limited results.
+
+    Args:
+        automation_id: REQUIRED - The automation ID (e.g., 'motion_light' or 'automation.motion_light')
+        domain: Domain to query ('automation' or 'script'). Default: 'automation'
+        limit: Maximum traces to return (default: 10, max: 50)
+
+    Returns:
+        A dictionary containing:
+        - traces: List of lean summaries (run_id, timestamp, trigger, state, outcome)
+        - automation_id: The automation queried
+        - domain: The domain queried
+        - count: Number of traces returned
+    """
+    try:
+        # Enforce limit bounds
+        limit = min(max(1, limit), 50)
+
+        # Strip domain prefix if present
+        if automation_id.startswith(f"{domain}."):
+            automation_id = automation_id.split(".", 1)[1]
+
+        # Call trace/list WebSocket API with specific item_id
+        traces = await call_websocket_api(
+            "trace/list",
+            domain=domain,
+            item_id=automation_id
+        )
+
+        if not traces:
+            return {
+                "automation_id": automation_id,
+                "domain": domain,
+                "traces": [],
+                "count": 0
+            }
+
+        # Extract traces for this automation
+        raw_traces = []
+        if isinstance(traces, dict) and automation_id in traces:
+            raw_traces = traces[automation_id]
+        elif isinstance(traces, list):
+            raw_traces = traces
+
+        # Build lean trace summaries - only essential fields
+        lean_traces = []
+        for trace in raw_traces[:limit]:
+            lean_trace = {
+                "run_id": trace.get("run_id"),
+                "timestamp": trace.get("timestamp", {}).get("start"),
+                "trigger": trace.get("trigger"),
+                "state": trace.get("state"),
+            }
+            # Include outcome if present
+            if trace.get("script_execution"):
+                lean_trace["outcome"] = trace["script_execution"]
+            lean_traces.append(lean_trace)
+
+        return {
+            "automation_id": automation_id,
+            "domain": domain,
+            "traces": lean_traces,
+            "count": len(lean_traces)
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing automation traces: {str(e)}")
+        return {
+            "automation_id": automation_id,
+            "domain": domain,
+            "traces": [],
+            "count": 0,
+            "error": f"Error listing traces: {str(e)}"
+        }
+
+
+@handle_api_errors
+async def get_automation_trace(
+    automation_id: str,
+    run_id: str,
+    domain: str = "automation"
+) -> Dict[str, Any]:
+    """
+    Get detailed trace information for a specific automation run.
+
+    Uses the WebSocket API to retrieve full execution details including
+    trigger info, condition results, action execution, and any errors.
+
+    Args:
+        automation_id: The automation ID (e.g., 'motion_light' or 'automation.motion_light')
+        run_id: The specific run/trace ID to retrieve
+        domain: The domain ('automation' or 'script'). Default: 'automation'
+
+    Returns:
+        A dictionary containing the full trace with:
+        - trace: Complete trace data including trigger, conditions, actions
+        - automation_id: The automation ID
+        - run_id: The run ID
+        - domain: The domain
+        - error: Error message if retrieval failed
+    """
+    try:
+        # Strip domain prefix if present
+        if automation_id.startswith(f"{domain}."):
+            automation_id = automation_id.split(".", 1)[1]
+
+        # Call trace/get WebSocket API
+        trace = await call_websocket_api(
+            "trace/get",
+            domain=domain,
+            item_id=automation_id,
+            run_id=run_id
+        )
+
+        return {
+            "automation_id": automation_id,
+            "run_id": run_id,
+            "domain": domain,
+            "trace": trace
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting automation trace: {str(e)}")
+        return {
+            "automation_id": automation_id,
+            "run_id": run_id,
+            "domain": domain,
+            "trace": None,
+            "error": f"Error getting trace: {str(e)}"
+        }
+
+
 def parse_datetime(dt_input: Union[str, datetime]) -> datetime:
     """
     Parse datetime input to timezone-aware datetime object.

--- a/app/hass.py
+++ b/app/hass.py
@@ -506,6 +506,108 @@ async def get_hass_error_log() -> Dict[str, Any]:
             "integration_mentions": {}
         }
 
+def parse_datetime(dt_input: Union[str, datetime]) -> datetime:
+    """
+    Parse datetime input to timezone-aware datetime object.
+    Simple implementation supporting ISO 8601 and basic keywords.
+
+    Supported formats:
+    - ISO 8601: "2025-10-28T10:00:00Z", "2025-10-28T10:00:00+00:00"
+    - Date only: "2025-10-28" (assumes start of day in UTC)
+    - Keywords: "now", "today", "yesterday"
+
+    Returns:
+        datetime: Timezone-aware datetime in UTC
+    """
+    if isinstance(dt_input, datetime):
+        return dt_input if dt_input.tzinfo else dt_input.replace(tzinfo=timezone.utc)
+
+    dt_str = str(dt_input).strip()
+
+    # Handle special keywords
+    if dt_str.lower() == "now":
+        return datetime.now(timezone.utc)
+    if dt_str.lower() == "today":
+        return datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    if dt_str.lower() == "yesterday":
+        today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        return today - timedelta(days=1)
+
+    # Handle date-only format (YYYY-MM-DD)
+    if len(dt_str) == 10 and dt_str[4] == '-' and dt_str[7] == '-':
+        dt = datetime.strptime(dt_str, "%Y-%m-%d")
+        return dt.replace(tzinfo=timezone.utc)
+
+    # Handle ISO 8601
+    if dt_str.endswith('Z'):
+        dt_str = dt_str[:-1] + '+00:00'
+
+    try:
+        dt = datetime.fromisoformat(dt_str)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        raise ValueError(
+            f"Invalid datetime format: {dt_input}. "
+            f"Use ISO 8601 (e.g., '2025-10-28T10:00:00Z'), "
+            f"date only (e.g., '2025-10-28'), "
+            f"or keywords: 'now', 'today', 'yesterday'"
+        )
+
+@handle_api_errors
+async def get_entity_history_range(
+    entity_id: str,
+    start_time: Union[str, datetime],
+    end_time: Optional[Union[str, datetime]] = None,
+    minimal_response: bool = True
+) -> List[Dict[str, Any]]:
+    """
+    Get entity history for a specific date/time range.
+
+    Args:
+        entity_id: The entity ID to get history for
+        start_time: ISO 8601 string or datetime object
+        end_time: ISO 8601 string or datetime object (defaults to now)
+        minimal_response: Reduce response size (default: True)
+
+    Returns:
+        A list of state change objects, or an error dictionary
+    """
+    client = await get_client()
+
+    # Parse start_time
+    start_dt = parse_datetime(start_time)
+
+    # Parse end_time (default to now)
+    if end_time is None:
+        end_dt = datetime.now(timezone.utc)
+    else:
+        end_dt = parse_datetime(end_time)
+
+    # Validate time range
+    if start_dt >= end_dt:
+        raise ValueError(f"start_time must be before end_time")
+
+    # Format for API
+    start_time_iso = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_time_iso = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Construct the API URL
+    url = f"{HA_URL}/api/history/period/{start_time_iso}"
+
+    # Set query parameters
+    params = {
+        "filter_entity_id": entity_id,
+        "minimal_response": str(minimal_response).lower(),
+        "end_time": end_time_iso,
+    }
+
+    # Make the API call
+    response = await client.get(url, headers=get_ha_headers(), params=params)
+    response.raise_for_status()
+
+    # Return the JSON response
+    return response.json()
+
 @handle_api_errors
 async def get_entity_history(entity_id: str, hours: int) -> List[Dict[str, Any]]:
     """
@@ -518,32 +620,17 @@ async def get_entity_history(entity_id: str, hours: int) -> List[Dict[str, Any]]
     Returns:
         A list of state change objects, or an error dictionary.
     """
-    client = await get_client()
-    
-    # Calculate the end time for the history lookup
+    # Calculate time range
     end_time = datetime.now(timezone.utc)
-    end_time_iso = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    # Calculate the start time for the history lookup based on end_time
     start_time = end_time - timedelta(hours=hours)
-    start_time_iso = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Construct the API URL
-    url = f"{HA_URL}/api/history/period/{start_time_iso}"
-    
-    # Set query parameters
-    params = {
-        "filter_entity_id": entity_id,
-        "minimal_response": "true",
-        "end_time": end_time_iso,
-    }
-    
-    # Make the API call
-    response = await client.get(url, headers=get_ha_headers(), params=params)
-    response.raise_for_status()
-    
-    # Return the JSON response
-    return response.json()
+    # Delegate to the range function
+    return await get_entity_history_range(
+        entity_id=entity_id,
+        start_time=start_time,
+        end_time=end_time,
+        minimal_response=True
+    )
 
 @handle_api_errors
 async def get_system_overview() -> Dict[str, Any]:

--- a/app/hass.py
+++ b/app/hass.py
@@ -44,6 +44,33 @@ DOMAIN_IMPORTANT_ATTRIBUTES = {
     "script": ["last_triggered"],
 }
 
+# Sensitive keys that should be redacted in logs
+_SENSITIVE_KEYS = frozenset([
+    "token", "password", "api_key", "secret", "access_token",
+    "authorization", "auth", "credential", "key", "pin", "code"
+])
+
+
+def sanitize_for_logging(data: Any) -> Any:
+    """
+    Sanitize data for safe logging by redacting sensitive fields.
+
+    Args:
+        data: The data to sanitize (dict, list, or primitive)
+
+    Returns:
+        Sanitized copy of the data with sensitive values redacted
+    """
+    if isinstance(data, dict):
+        return {
+            k: "***REDACTED***" if k.lower() in _SENSITIVE_KEYS else sanitize_for_logging(v)
+            for k, v in data.items()
+        }
+    elif isinstance(data, list):
+        return [sanitize_for_logging(item) for item in data]
+    else:
+        return data
+
 def handle_api_errors(func: F) -> F:
     """
     Decorator to handle common error cases for Home Assistant API calls

--- a/app/hass.py
+++ b/app/hass.py
@@ -254,9 +254,30 @@ async def call_websocket_api(message_type: str, **kwargs) -> Dict[str, Any]:
             else:
                 raise Exception(f"Unexpected auth message: {auth_data}")
 
+    except ssl.SSLError as e:
+        logger.error(f"SSL/TLS error connecting to Home Assistant: {str(e)}")
+        raise Exception(f"SSL certificate error: {str(e)}")
+    except websockets.exceptions.InvalidURI as e:
+        logger.error(f"Invalid WebSocket URI: {ws_url}")
+        raise Exception(f"Invalid WebSocket URI: {str(e)}")
+    except websockets.exceptions.ConnectionClosed as e:
+        logger.error(f"WebSocket connection closed unexpectedly: {e.code} - {e.reason}")
+        raise Exception(f"WebSocket connection closed: {e.reason or 'Unknown reason'}")
     except websockets.exceptions.WebSocketException as e:
         logger.error(f"WebSocket connection error: {str(e)}")
         raise Exception(f"WebSocket connection failed: {str(e)}")
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse WebSocket response: {str(e)}")
+        raise Exception(f"Invalid response from Home Assistant: {str(e)}")
+    except asyncio.TimeoutError:
+        logger.error(f"WebSocket connection to {ws_url} timed out")
+        raise Exception(f"WebSocket connection timed out")
+    except ConnectionRefusedError:
+        logger.error(f"Connection refused to {ws_url}")
+        raise Exception(f"Connection refused: Home Assistant not reachable at {HA_URL}")
+    except OSError as e:
+        logger.error(f"Network error connecting to {ws_url}: {str(e)}")
+        raise Exception(f"Network error: {str(e)}")
     except Exception as e:
         logger.error(f"WebSocket API error: {str(e)}")
         raise

--- a/app/hass.py
+++ b/app/hass.py
@@ -125,6 +125,53 @@ _timeout_config = httpx.Timeout(
     pool=5.0        # Pool timeout - waiting for available connection
 )
 
+
+class RateLimiter:
+    """
+    Simple async rate limiter using token bucket algorithm.
+    Limits requests to max_rate per second.
+    """
+
+    def __init__(self, max_rate: float = 10.0):
+        """
+        Initialize rate limiter.
+
+        Args:
+            max_rate: Maximum requests per second (default: 10)
+        """
+        self.max_rate = max_rate
+        self.tokens = max_rate
+        self.last_update: float = 0.0  # Will be set on first acquire()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Wait until a request token is available."""
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            now = loop.time()
+
+            # On first call, just set last_update and use existing tokens
+            if self.last_update == 0.0:
+                self.last_update = now
+            else:
+                # Refill tokens based on time passed
+                time_passed = now - self.last_update
+                self.tokens = min(self.max_rate, self.tokens + time_passed * self.max_rate)
+                self.last_update = now
+
+            if self.tokens < 1:
+                # Wait for token to become available
+                wait_time = (1 - self.tokens) / self.max_rate
+                await asyncio.sleep(wait_time)
+                self.tokens = 0
+            else:
+                self.tokens -= 1
+
+
+# Global rate limiter - 10 requests per second
+_rate_limiter = RateLimiter(max_rate=10.0)
+
+
 async def get_client() -> httpx.AsyncClient:
     """Get a persistent httpx client for Home Assistant API calls"""
     global _client
@@ -163,6 +210,8 @@ async def call_websocket_api(message_type: str, **kwargs) -> Dict[str, Any]:
         # Validates certificates by default - no need for explicit verify_mode
 
     try:
+        # Apply rate limiting before making connection
+        await _rate_limiter.acquire()
         async with websockets.connect(ws_url, ssl=ssl_context) as websocket:
             # Wait for auth required message
             auth_msg = await websocket.recv()
@@ -215,6 +264,7 @@ async def call_websocket_api(message_type: str, **kwargs) -> Dict[str, Any]:
 # Direct entity retrieval function
 async def get_all_entity_states() -> Dict[str, Dict[str, Any]]:
     """Fetch all entity states from Home Assistant"""
+    await _rate_limiter.acquire()
     client = await get_client()
     response = await client.get(f"{HA_URL}/api/states", headers=get_ha_headers())
     response.raise_for_status()
@@ -271,6 +321,7 @@ def filter_fields(data: Dict[str, Any], fields: List[str]) -> Dict[str, Any]:
 @handle_api_errors
 async def get_hass_version() -> str:
     """Get the Home Assistant version from the API"""
+    await _rate_limiter.acquire()
     client = await get_client()
     response = await client.get(f"{HA_URL}/api/config", headers=get_ha_headers())
     response.raise_for_status()
@@ -300,9 +351,10 @@ async def get_entity_state(
         Entity state dictionary, optionally filtered to include only specified fields
     """
     # Fetch directly
+    await _rate_limiter.acquire()
     client = await get_client()
     response = await client.get(
-        f"{HA_URL}/api/states/{entity_id}", 
+        f"{HA_URL}/api/states/{entity_id}",
         headers=get_ha_headers()
     )
     response.raise_for_status()
@@ -350,6 +402,7 @@ async def get_entities(
         and optionally limited to specific fields
     """
     # Get all entities directly
+    await _rate_limiter.acquire()
     client = await get_client()
     response = await client.get(f"{HA_URL}/api/states", headers=get_ha_headers())
     response.raise_for_status()
@@ -427,7 +480,8 @@ async def call_service(domain: str, service: str, data: Optional[Dict[str, Any]]
     """Call a Home Assistant service"""
     if data is None:
         data = {}
-    
+
+    await _rate_limiter.acquire()
     client = await get_client()
     response = await client.post(
         f"{HA_URL}/api/services/{domain}/{service}", 
@@ -815,6 +869,7 @@ async def get_entity_history_range(
     Returns:
         A list of state change objects, or an error dictionary
     """
+    await _rate_limiter.acquire()
     client = await get_client()
 
     # Parse start_time
@@ -1013,6 +1068,7 @@ async def get_system_overview() -> Dict[str, Any]:
     try:
         # Get ALL entities with minimal fields for efficiency
         # We retrieve all entities since API calls don't consume tokens, only responses do
+        await _rate_limiter.acquire()
         client = await get_client()
         response = await client.get(f"{HA_URL}/api/states", headers=get_ha_headers())
         response.raise_for_status()

--- a/app/hass.py
+++ b/app/hass.py
@@ -633,6 +633,153 @@ async def get_entity_history(entity_id: str, hours: int) -> List[Dict[str, Any]]
     )
 
 @handle_api_errors
+async def get_entity_statistics(
+    entity_id: str,
+    hours: int,
+    period: str = "5minute"
+) -> Dict[str, Any]:
+    """
+    Get statistical data for an entity for recent time period.
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        hours: Number of hours of statistics to retrieve
+        period: Statistics period: "5minute" or "hour"
+
+    Returns:
+        A dictionary containing statistical data with aggregated values
+    """
+    # Calculate time range
+    end_time = datetime.now(timezone.utc)
+    start_time = end_time - timedelta(hours=hours)
+
+    # Delegate to the range function
+    return await get_entity_statistics_range(
+        entity_id=entity_id,
+        start_time=start_time,
+        end_time=end_time,
+        period=period
+    )
+
+@handle_api_errors
+async def get_entity_statistics_range(
+    entity_id: str,
+    start_time: Union[str, datetime],
+    end_time: Optional[Union[str, datetime]] = None,
+    period: str = "hour"
+) -> Dict[str, Any]:
+    """
+    Get statistical data for an entity for a specific date/time range.
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        start_time: ISO 8601 string or datetime object
+        end_time: ISO 8601 string or datetime object (defaults to now)
+        period: Statistics period: "5minute", "hour", "day", "week", or "month"
+
+    Returns:
+        A dictionary containing:
+        - entity_id: The entity ID requested
+        - period: The period requested
+        - start_time: The actual start time used
+        - end_time: The actual end time used
+        - statistics: List of statistical data points with mean, min, max values
+    """
+    client = await get_client()
+
+    # Parse start_time
+    start_dt = parse_datetime(start_time)
+
+    # Parse end_time (default to now)
+    if end_time is None:
+        end_dt = datetime.now(timezone.utc)
+    else:
+        end_dt = parse_datetime(end_time)
+
+    # Validate time range
+    if start_dt >= end_dt:
+        raise ValueError(f"start_time must be before end_time")
+
+    # Format for API
+    start_time_iso = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    end_time_iso = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Construct the API URL - using the statistics endpoint
+    url = f"{HA_URL}/api/history/period/{start_time_iso}"
+
+    # Map our period names to HA's expected values
+    period_map = {
+        "5minute": "5minute",
+        "hour": "hour",
+        "day": "day",
+        "week": "week",
+        "month": "month"
+    }
+
+    if period not in period_map:
+        raise ValueError(f"Invalid period: {period}. Must be one of: {list(period_map.keys())}")
+
+    # Set query parameters for statistics
+    params = {
+        "statistic_ids": entity_id,
+        "period": period_map[period],
+        "end_time": end_time_iso,
+    }
+
+    # Make the API call to statistics endpoint
+    # Note: HA's statistics API endpoint is different
+    stats_url = f"{HA_URL}/api/statistics/during_period"
+
+    # Prepare the request body for statistics
+    body = {
+        "statistic_ids": [entity_id],
+        "period": period_map[period],
+        "start_time": start_time_iso,
+        "end_time": end_time_iso,
+        "types": ["mean", "min", "max", "change", "sum"]
+    }
+
+    # Make the API call (POST request with JSON body)
+    response = await client.post(
+        stats_url,
+        headers=get_ha_headers(),
+        json=body
+    )
+
+    if response.status_code == 404:
+        # Statistics might not be available for this entity
+        # Try alternative endpoint or return informative error
+        return {
+            "entity_id": entity_id,
+            "period": period,
+            "start_time": start_time_iso,
+            "end_time": end_time_iso,
+            "statistics": [],
+            "error": f"No statistics available for entity {entity_id}. This entity may not support long-term statistics."
+        }
+
+    response.raise_for_status()
+    data = response.json()
+
+    # Format the response
+    result = {
+        "entity_id": entity_id,
+        "period": period,
+        "start_time": start_time_iso,
+        "end_time": end_time_iso,
+        "statistics": []
+    }
+
+    # Extract statistics from the response
+    if entity_id in data:
+        result["statistics"] = data[entity_id]
+    elif isinstance(data, list) and len(data) > 0:
+        # Sometimes HA returns statistics as a list
+        result["statistics"] = data
+
+    return result
+
+@handle_api_errors
 async def get_system_overview() -> Dict[str, Any]:
     """
     Get a comprehensive overview of the entire Home Assistant system

--- a/app/hass.py
+++ b/app/hass.py
@@ -172,10 +172,14 @@ async def get_hass_version() -> str:
 async def get_entity_state(
     entity_id: str,
     fields: Optional[List[str]] = None,
-    lean: bool = False
+    lean: bool = False,
+    use_cache: bool = False  # Accept but ignore for now - TODO: implement caching
 ) -> Dict[str, Any]:
     """
     Get the state of a Home Assistant entity
+
+    TODO: Implement caching logic when use_cache=True
+    This would reduce API calls and improve performance for frequently accessed entities
     
     Args:
         entity_id: The entity ID to get

--- a/app/hass.py
+++ b/app/hass.py
@@ -47,7 +47,9 @@ DOMAIN_IMPORTANT_ATTRIBUTES = {
 # Sensitive keys that should be redacted in logs
 _SENSITIVE_KEYS = frozenset([
     "token", "password", "api_key", "secret", "access_token",
-    "authorization", "auth", "credential", "key", "pin", "code"
+    "authorization", "auth", "credential", "key", "pin", "code",
+    "bearer", "refresh_token", "client_secret", "private_key",
+    "passphrase", "session", "cookie"
 ])
 
 
@@ -163,7 +165,8 @@ class RateLimiter:
                 # Wait for token to become available
                 wait_time = (1 - self.tokens) / self.max_rate
                 await asyncio.sleep(wait_time)
-                self.tokens = 0
+                # Token is now available after waiting - deduct it
+                self.tokens -= 1
             else:
                 self.tokens -= 1
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -4,6 +4,9 @@ import functools
 import inspect
 import logging
 from datetime import datetime, timedelta, timezone
+import json
+import asyncio
+import websockets
 
 from app.config import HA_URL, HA_TOKEN, get_ha_headers
 
@@ -102,6 +105,71 @@ async def cleanup_client() -> None:
         logger.debug("Closing HTTP client")
         await _client.aclose()
         _client = None
+
+async def call_websocket_api(message_type: str, **kwargs) -> Dict[str, Any]:
+    """
+    Call Home Assistant WebSocket API.
+
+    Args:
+        message_type: The WebSocket message type (e.g., 'recorder/statistics_during_period')
+        **kwargs: Additional parameters for the message
+
+    Returns:
+        The response from Home Assistant
+    """
+    # Convert HTTP URL to WebSocket URL
+    ws_url = HA_URL.replace("http://", "ws://").replace("https://", "wss://")
+    ws_url = f"{ws_url}/api/websocket"
+
+    try:
+        async with websockets.connect(ws_url) as websocket:
+            # Wait for auth required message
+            auth_msg = await websocket.recv()
+            auth_data = json.loads(auth_msg)
+
+            if auth_data.get("type") == "auth_required":
+                # Send authentication
+                await websocket.send(json.dumps({
+                    "type": "auth",
+                    "access_token": HA_TOKEN
+                }))
+
+                # Wait for auth result
+                auth_result = await websocket.recv()
+                auth_result_data = json.loads(auth_result)
+
+                if auth_result_data.get("type") != "auth_ok":
+                    raise Exception(f"Authentication failed: {auth_result_data}")
+
+                # Now send the actual request
+                message_id = 1
+                message = {
+                    "id": message_id,
+                    "type": message_type,
+                    **kwargs
+                }
+
+                await websocket.send(json.dumps(message))
+
+                # Wait for response
+                response = await websocket.recv()
+                response_data = json.loads(response)
+
+                # Check for success
+                if response_data.get("success") is False:
+                    error = response_data.get("error", {})
+                    raise Exception(f"WebSocket API error: {error.get('message', 'Unknown error')}")
+
+                return response_data.get("result", {})
+            else:
+                raise Exception(f"Unexpected auth message: {auth_data}")
+
+    except websockets.exceptions.WebSocketException as e:
+        logger.error(f"WebSocket connection error: {str(e)}")
+        raise Exception(f"WebSocket connection failed: {str(e)}")
+    except Exception as e:
+        logger.error(f"WebSocket API error: {str(e)}")
+        raise
 
 # Direct entity retrieval function
 async def get_all_entity_states() -> Dict[str, Dict[str, Any]]:
@@ -685,8 +753,6 @@ async def get_entity_statistics_range(
         - end_time: The actual end time used
         - statistics: List of statistical data points with mean, min, max values
     """
-    client = await get_client()
-
     # Parse start_time
     start_dt = parse_datetime(start_time)
 
@@ -704,9 +770,6 @@ async def get_entity_statistics_range(
     start_time_iso = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
     end_time_iso = end_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    # Construct the API URL - using the statistics endpoint
-    url = f"{HA_URL}/api/history/period/{start_time_iso}"
-
     # Map our period names to HA's expected values
     period_map = {
         "5minute": "5minute",
@@ -719,65 +782,45 @@ async def get_entity_statistics_range(
     if period not in period_map:
         raise ValueError(f"Invalid period: {period}. Must be one of: {list(period_map.keys())}")
 
-    # Set query parameters for statistics
-    params = {
-        "statistic_ids": entity_id,
-        "period": period_map[period],
-        "end_time": end_time_iso,
-    }
+    try:
+        # Use WebSocket API to get statistics
+        result = await call_websocket_api(
+            "recorder/statistics_during_period",
+            start_time=start_time_iso,
+            end_time=end_time_iso,
+            statistic_ids=[entity_id],
+            period=period_map[period],
+            types=["mean", "min", "max", "state", "sum"]
+        )
 
-    # Make the API call to statistics endpoint
-    # Note: HA's statistics API endpoint is different
-    stats_url = f"{HA_URL}/api/statistics/during_period"
+        # Extract statistics from the response
+        statistics = []
+        if entity_id in result:
+            statistics = result[entity_id]
+        elif isinstance(result, dict) and len(result) > 0:
+            # Sometimes returns with different key format
+            first_key = list(result.keys())[0]
+            statistics = result[first_key]
 
-    # Prepare the request body for statistics
-    body = {
-        "statistic_ids": [entity_id],
-        "period": period_map[period],
-        "start_time": start_time_iso,
-        "end_time": end_time_iso,
-        "types": ["mean", "min", "max", "change", "sum"]
-    }
+        return {
+            "entity_id": entity_id,
+            "period": period,
+            "start_time": start_time_iso,
+            "end_time": end_time_iso,
+            "statistics": statistics
+        }
 
-    # Make the API call (POST request with JSON body)
-    response = await client.post(
-        stats_url,
-        headers=get_ha_headers(),
-        json=body
-    )
-
-    if response.status_code == 404:
-        # Statistics might not be available for this entity
-        # Try alternative endpoint or return informative error
+    except Exception as e:
+        logger.error(f"Error getting statistics for {entity_id}: {str(e)}")
+        # Return empty statistics with error message
         return {
             "entity_id": entity_id,
             "period": period,
             "start_time": start_time_iso,
             "end_time": end_time_iso,
             "statistics": [],
-            "error": f"No statistics available for entity {entity_id}. This entity may not support long-term statistics."
+            "error": f"Failed to retrieve statistics: {str(e)}"
         }
-
-    response.raise_for_status()
-    data = response.json()
-
-    # Format the response
-    result = {
-        "entity_id": entity_id,
-        "period": period,
-        "start_time": start_time_iso,
-        "end_time": end_time_iso,
-        "statistics": []
-    }
-
-    # Extract statistics from the response
-    if entity_id in data:
-        result["statistics"] = data[entity_id]
-    elif isinstance(data, list) and len(data) > 0:
-        # Sometimes HA returns statistics as a list
-        result["statistics"] = data
-
-    return result
 
 @handle_api_errors
 async def get_system_overview() -> Dict[str, Any]:

--- a/app/server.py
+++ b/app/server.py
@@ -18,7 +18,8 @@ from app.hass import (
     get_hass_version, get_entity_state, call_service, get_entities,
     get_automations, restart_home_assistant,
     cleanup_client, filter_fields, summarize_domain, get_system_overview,
-    get_hass_error_log, get_entity_history, get_entity_history_range
+    get_hass_error_log, get_entity_history, get_entity_history_range,
+    list_automation_traces, get_automation_trace
 )
 
 # Type variable for generic functions
@@ -861,7 +862,85 @@ async def list_automations() -> List[Dict[str, Any]]:
         logger.error(f"Error in list_automations: {str(e)}")
         return []
 
-# We already have a list_automations tool, so no need to duplicate functionality
+
+@mcp.tool()
+@async_handler("list_automation_traces")
+async def list_automation_traces_tool(
+    automation_id: str,
+    domain: str = "automation",
+    limit: int = 10
+) -> Dict[str, Any]:
+    """
+    List recent execution traces for a specific automation
+
+    Args:
+        automation_id: REQUIRED - The automation ID (e.g., 'motion_light' or 'automation.motion_light')
+        domain: Domain to query ('automation' or 'script'). Default: 'automation'
+        limit: Maximum traces to return (default: 10, max: 50)
+
+    Returns:
+        Dictionary with:
+        - traces: List of lean summaries (run_id, timestamp, trigger, state, outcome)
+        - automation_id: The automation queried
+        - domain: The domain queried
+        - count: Number of traces returned
+
+    Examples:
+        automation_id="motion_light" - get last 10 traces
+        automation_id="kitchen_lights", limit=5 - get last 5 traces
+
+    Best Practices:
+        - Use run_id with get_automation_trace to get full details
+        - Check 'outcome' field: 'finished', 'failed_conditions', 'aborted'
+        - 'state: running' means automation still executing
+    """
+    logger.info(f"Listing traces for automation: {automation_id}, limit: {limit}")
+    return await list_automation_traces(automation_id, domain, limit)
+
+
+@mcp.tool()
+@async_handler("get_automation_trace")
+async def get_automation_trace_tool(
+    automation_id: str,
+    run_id: str,
+    domain: str = "automation"
+) -> Dict[str, Any]:
+    """
+    Get detailed trace for a specific automation run
+
+    Retrieves complete execution details including trigger info, condition
+    evaluation results, action execution steps, variables, and any errors.
+
+    Args:
+        automation_id: The automation ID (e.g., 'motion_light' or 'automation.motion_light')
+        run_id: The specific run/trace ID from list_automation_traces
+        domain: Domain ('automation' or 'script'). Default: 'automation'
+
+    Returns:
+        Dictionary with:
+        - trace: Complete trace data including:
+          * trigger: What triggered the automation
+          * condition: Condition evaluation results (if any)
+          * action: Step-by-step action execution
+          * variables: Variables at each step
+          * error: Error details if the run failed
+        - automation_id: The automation queried
+        - run_id: The run ID queried
+        - domain: The domain
+
+    Examples:
+        automation_id="motion_light", run_id="1700000000.123456"
+        automation_id="automation.bedtime_routine", run_id="1700000000.789"
+
+    Best Practices:
+        - First use list_automation_traces to find the run_id
+        - Check 'trace.trace' for step-by-step execution path
+        - Look for 'result' fields to see what each step returned
+        - Examine 'error' fields for failure details
+    """
+    logger.info(f"Getting trace for automation: {automation_id}, run_id: {run_id}")
+    return await get_automation_trace(automation_id, run_id, domain)
+
 
 @mcp.tool()
 @async_handler("restart_ha")

--- a/app/server.py
+++ b/app/server.py
@@ -1526,23 +1526,24 @@ async def get_statistics_range(
 @async_handler("get_error_log")
 async def get_error_log() -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting using WebSocket API
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
+        - records: List of error/warning log records (each with timestamp, level, name, message)
         - error_count: Number of ERROR entries found
         - warning_count: Number of WARNING entries found
         - integration_mentions: Map of integration names to mention counts
         - error: Error message if retrieval failed
-        
+
     Examples:
-        Returns errors, warnings count and integration mentions
+        Returns structured log records with errors and warnings count
     Best Practices:
         - Use this tool when troubleshooting specific Home Assistant errors
         - Look for patterns in repeated errors
         - Pay attention to timestamps to correlate errors with events
-        - Focus on integrations with many mentions in the log    
+        - Focus on integrations with many mentions in the log
+        - Note: Only returns the 50 most recent errors/warnings (Home Assistant default)
     """
     logger.info("Getting Home Assistant error log")
     return await get_hass_error_log()

--- a/app/server.py
+++ b/app/server.py
@@ -19,7 +19,8 @@ from app.hass import (
     get_automations, restart_home_assistant,
     cleanup_client, filter_fields, summarize_domain, get_system_overview,
     get_hass_error_log, get_entity_history, get_entity_history_range,
-    list_automation_traces, get_automation_trace
+    list_automation_traces, get_automation_trace,
+    sanitize_for_logging
 )
 
 # Type variable for generic functions
@@ -122,7 +123,7 @@ async def entity_action(entity_id: str, action: str, params: Optional[Dict[str, 
     # Prepare service data
     data = {"entity_id": entity_id, **(params or {})}
     
-    logger.info(f"Performing action '{action}' on entity: {entity_id} with params: {params}")
+    logger.info(f"Performing action '{action}' on entity: {entity_id} with params: {sanitize_for_logging(params)}")
     return await call_service(domain, service, data)
 
 @mcp.resource("hass://entities/{entity_id}")
@@ -976,7 +977,7 @@ async def call_service_tool(domain: str, service: str, data: Optional[Dict[str, 
         domain='fan', service='set_percentage', data={'entity_id': 'fan.x', 'percentage': 50}
     
     """
-    logger.info(f"Calling Home Assistant service: {domain}.{service} with data: {data}")
+    logger.info(f"Calling Home Assistant service: {domain}.{service} with data: {sanitize_for_logging(data)}")
     return await call_service(domain, service, data or {})
 
 # Prompt functionality

--- a/app/server.py
+++ b/app/server.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 from app.hass import (
     get_hass_version, get_entity_state, call_service, get_entities,
-    get_automations, restart_home_assistant, 
+    get_automations, restart_home_assistant,
     cleanup_client, filter_fields, summarize_domain, get_system_overview,
-    get_hass_error_log, get_entity_history
+    get_hass_error_log, get_entity_history, get_entity_history_range
 )
 
 # Type variable for generic functions
@@ -1200,6 +1200,110 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
             "error": f"Error processing history: {str(e)}",
             "states": [],
             "count": 0
+        }
+
+@mcp.tool()
+@async_handler("get_history_range")
+async def get_history_range(
+    entity_id: str,
+    start_time: str,
+    end_time: Optional[str] = None,
+    minimal_response: bool = True
+) -> Dict[str, Any]:
+    """
+    Get entity history for a specific date/time range
+
+    Args:
+        entity_id: The entity ID to get history for
+        start_time: Start time (ISO 8601, date only, or 'yesterday'/'today')
+        end_time: End time (optional, defaults to 'now')
+        minimal_response: Reduce response size (default: true)
+
+    Returns:
+        A dictionary containing:
+        - entity_id: The entity ID requested
+        - states: List of state objects with timestamps
+        - count: Number of state changes found
+        - start_time: Requested start time
+        - end_time: Requested or defaulted end time
+        - first_changed: Timestamp of earliest state change
+        - last_changed: Timestamp of most recent state change
+
+    Examples:
+        entity_id="sensor.temperature", start_time="2025-10-28T00:00:00Z"
+        entity_id="light.living_room", start_time="yesterday", end_time="today"
+        entity_id="switch.pump", start_time="2025-10-27", end_time="2025-10-28"
+        entity_id="sensor.humidity", start_time="2025-10-01T10:00:00Z", end_time="now"
+    """
+    logger.info(f"Getting history range for entity: {entity_id}, start: {start_time}, end: {end_time}")
+
+    try:
+        # Get history using the new range function
+        history_data = await get_entity_history_range(entity_id, start_time, end_time, minimal_response)
+
+        # Check for errors from the API call
+        if isinstance(history_data, dict) and "error" in history_data:
+            return {
+                "entity_id": entity_id,
+                "error": history_data["error"],
+                "states": [],
+                "count": 0,
+                "start_time": start_time,
+                "end_time": end_time or "now"
+            }
+
+        # Process the result (same as get_history)
+        states = []
+        if history_data and isinstance(history_data, list):
+            for state_list in history_data:
+                states.extend(state_list)
+
+        if not states:
+            return {
+                "entity_id": entity_id,
+                "states": [],
+                "count": 0,
+                "start_time": start_time,
+                "end_time": end_time or "now",
+                "message": "No state changes found in the specified range"
+            }
+
+        # Sort states by last_changed timestamp
+        states.sort(key=lambda x: x.get("last_changed", ""))
+
+        # Extract first and last changed timestamps
+        first_changed = states[0].get("last_changed") if states else None
+        last_changed = states[-1].get("last_changed") if states else None
+
+        return {
+            "entity_id": entity_id,
+            "states": states,
+            "count": len(states),
+            "start_time": start_time,
+            "end_time": end_time or "now",
+            "first_changed": first_changed,
+            "last_changed": last_changed
+        }
+    except ValueError as e:
+        # Handle date parsing errors
+        logger.error(f"Date parsing error for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": str(e),
+            "states": [],
+            "count": 0,
+            "start_time": start_time,
+            "end_time": end_time or "now"
+        }
+    except Exception as e:
+        logger.error(f"Error processing history range for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": f"Error processing history: {str(e)}",
+            "states": [],
+            "count": 0,
+            "start_time": start_time,
+            "end_time": end_time or "now"
         }
 
 @mcp.tool()

--- a/app/server.py
+++ b/app/server.py
@@ -1130,7 +1130,7 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
     ⚠️ TOKEN LIMIT WARNING:
     - Returns EVERY state change in the period
     - Response size depends on sensor update frequency × time range
-    - Maximum response: 25,000 tokens
+    - May exceed token limits for some LLM clients
     - Consider using get_statistics for aggregated data instead
 
     When to use this tool:
@@ -1231,7 +1231,7 @@ async def get_history_range(
     ⚠️ TOKEN LIMIT WARNING:
     - Returns EVERY state change in the period
     - Response size = sensor update frequency × time range
-    - Maximum response: 25,000 tokens
+    - May exceed token limits for some LLM clients
     - High risk of exceeding limits with date ranges
 
     When to use this tool:

--- a/app/server.py
+++ b/app/server.py
@@ -1127,7 +1127,7 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
     """
     Get RAW state changes for an entity (every single state change)
 
-    ⚠️ TOKEN LIMIT WARNING:
+    TOKEN LIMIT WARNING:
     - Returns EVERY state change in the period
     - Response size depends on sensor update frequency × time range
     - May exceed token limits for some LLM clients
@@ -1228,7 +1228,7 @@ async def get_history_range(
     """
     Get RAW state changes for a specific date/time range
 
-    ⚠️ TOKEN LIMIT WARNING:
+    TOKEN LIMIT WARNING:
     - Returns EVERY state change in the period
     - Response size = sensor update frequency × time range
     - May exceed token limits for some LLM clients
@@ -1348,7 +1348,7 @@ async def get_statistics(
     """
     Get AGGREGATED statistics for an entity (mean, min, max values)
 
-    ✅ TOKEN EFFICIENT - Returns aggregated data instead of raw states
+    TOKEN EFFICIENT - Returns aggregated data instead of raw states
     - Uses Home Assistant's pre-calculated statistics via WebSocket
     - Much smaller response size than raw history
     - Perfect for trends, graphs, and analysis
@@ -1431,7 +1431,7 @@ async def get_statistics_range(
     """
     Get AGGREGATED statistics for a specific date/time range
 
-    ✅ BEST TOOL FOR HISTORICAL DATA - No token limits!
+    BEST TOOL FOR HISTORICAL DATA - No token limits!
     - Retrieves Home Assistant's long-term statistics via WebSocket
     - Can handle ANY date range efficiently (days, months, years)
     - Returns aggregated data (mean/min/max) instead of raw states

--- a/app/server.py
+++ b/app/server.py
@@ -1125,12 +1125,28 @@ You'll help the user create optimized dashboards by:
 @async_handler("get_history")
 async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
     """
-    Get the history of an entity's state changes
-    
+    Get RAW state changes for an entity (every single state change)
+
+    ⚠️ TOKEN LIMIT WARNING:
+    - Returns EVERY state change in the period
+    - Response size depends on sensor update frequency × time range
+    - Maximum response: 25,000 tokens
+    - Consider using get_statistics for aggregated data instead
+
+    When to use this tool:
+    - You need exact timestamps of state changes
+    - Entity changes infrequently (e.g., doors, switches)
+    - Short time periods relative to the sensor's update frequency
+
+    When NOT to use this tool:
+    - You only need trends or aggregated values → use get_statistics
+    - Long time periods for frequently-updating sensors
+    - Response might exceed token limits → use get_statistics
+
     Args:
         entity_id: The entity ID to get history for
         hours: Number of hours of history to retrieve (default: 24)
-    
+
     Returns:
         A dictionary containing:
         - entity_id: The entity ID requested
@@ -1138,14 +1154,13 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
         - count: Number of state changes found
         - first_changed: Timestamp of earliest state change
         - last_changed: Timestamp of most recent state change
-        
+
     Examples:
-        entity_id="light.living_room" - get 24h history
-        entity_id="sensor.temperature", hours=168 - get 7 day history
-    Best Practices:
-        - Keep hours reasonable (24-72) for token efficiency
-        - Use for entities with discrete state changes rather than continuously changing sensors
-        - Consider the state distribution rather than every individual state    
+        entity_id="binary_sensor.front_door" - door open/close events
+        entity_id="sensor.temperature", hours=1 - one hour of temperature readings
+
+    Note: If this tool returns a token limit error, reduce the hours parameter
+    or switch to get_statistics for aggregated data.
     """
     logger.info(f"Getting history for entity: {entity_id}, hours: {hours}")
     
@@ -1211,7 +1226,23 @@ async def get_history_range(
     minimal_response: bool = True
 ) -> Dict[str, Any]:
     """
-    Get entity history for a specific date/time range
+    Get RAW state changes for a specific date/time range
+
+    ⚠️ TOKEN LIMIT WARNING:
+    - Returns EVERY state change in the period
+    - Response size = sensor update frequency × time range
+    - Maximum response: 25,000 tokens
+    - High risk of exceeding limits with date ranges
+
+    When to use this tool:
+    - You need exact timestamps of specific state changes
+    - Short, precise time windows
+    - Entities with infrequent state changes
+
+    When NOT to use this tool:
+    - Date ranges spanning days → use get_statistics_range
+    - Frequently-updating sensors → use get_statistics_range
+    - You only need aggregated values → use get_statistics_range
 
     Args:
         entity_id: The entity ID to get history for
@@ -1230,10 +1261,11 @@ async def get_history_range(
         - last_changed: Timestamp of most recent state change
 
     Examples:
-        entity_id="sensor.temperature", start_time="2025-10-28T00:00:00Z"
+        entity_id="sensor.temperature", start_time="2025-10-28T10:00:00Z", end_time="2025-10-28T11:00:00Z"
         entity_id="light.living_room", start_time="yesterday", end_time="today"
-        entity_id="switch.pump", start_time="2025-10-27", end_time="2025-10-28"
-        entity_id="sensor.humidity", start_time="2025-10-01T10:00:00Z", end_time="now"
+
+    Note: If you receive a token limit error, use get_statistics_range instead
+    for the same time period to get aggregated data.
     """
     logger.info(f"Getting history range for entity: {entity_id}, start: {start_time}, end: {end_time}")
 
@@ -1314,7 +1346,25 @@ async def get_statistics(
     period: str = "hour"
 ) -> Dict[str, Any]:
     """
-    Get statistical data for an entity for recent time period
+    Get AGGREGATED statistics for an entity (mean, min, max values)
+
+    ✅ TOKEN EFFICIENT - Returns aggregated data instead of raw states
+    - Uses Home Assistant's pre-calculated statistics via WebSocket
+    - Much smaller response size than raw history
+    - Perfect for trends, graphs, and analysis
+
+    When to use this tool:
+    - You need trends or patterns over time
+    - Large time ranges (days, weeks, months)
+    - Frequently-updating sensors
+    - You don't need exact state change timestamps
+
+    Aggregation Periods:
+    - "5minute": Most detailed, ~12 points per hour
+    - "hour": Good for daily views, 24 points per day
+    - "day": For monthly views
+    - "week": For quarterly views
+    - "month": For yearly views
 
     Args:
         entity_id: The entity ID to get statistics for
@@ -1325,18 +1375,19 @@ async def get_statistics(
         A dictionary containing:
         - entity_id: The entity ID requested
         - period: The period used
-        - statistics: List of statistical data points with mean, min, max values
+        - statistics: List of data points, each with:
+          * start: Timestamp (milliseconds)
+          * end: Timestamp (milliseconds)
+          * mean: Average value in period
+          * min: Minimum value in period
+          * max: Maximum value in period
         - count: Number of statistical data points
 
     Examples:
-        entity_id="sensor.temperature" - get 24h hourly statistics
-        entity_id="sensor.power_usage", hours=168, period="day" - get 7 days of daily stats
-        entity_id="sensor.humidity", hours=4, period="5minute" - get 4h of 5-minute stats
+        entity_id="sensor.temperature", hours=24, period="hour" - hourly averages for 24h
+        entity_id="sensor.power_usage", hours=168, period="day" - daily averages for 7 days
 
-    Best Practices:
-        - Use "5minute" period for recent data (< 10 days old)
-        - Use "hour" period for older data or long-term trends
-        - Token-efficient for large date ranges compared to raw states
+    Note: Returns empty statistics if entity doesn't support long-term statistics
     """
     logger.info(f"Getting statistics for entity: {entity_id}, hours: {hours}, period: {period}")
 
@@ -1378,7 +1429,25 @@ async def get_statistics_range(
     period: str = "hour"
 ) -> Dict[str, Any]:
     """
-    Get statistical data for an entity for a specific date/time range
+    Get AGGREGATED statistics for a specific date/time range
+
+    ✅ BEST TOOL FOR HISTORICAL DATA - No token limits!
+    - Retrieves Home Assistant's long-term statistics via WebSocket
+    - Can handle ANY date range efficiently (days, months, years)
+    - Returns aggregated data (mean/min/max) instead of raw states
+
+    When to use this tool:
+    - ANY date range query (especially multi-day)
+    - Historical data analysis
+    - Frequently-updating sensors over long periods
+    - When raw history exceeds token limits
+
+    Aggregation Periods:
+    - "5minute": For detailed recent data (last 10 days)
+    - "hour": Best for daily/weekly ranges
+    - "day": Best for monthly ranges
+    - "week": Best for quarterly ranges
+    - "month": Best for yearly ranges
 
     Args:
         entity_id: The entity ID to get statistics for
@@ -1392,18 +1461,21 @@ async def get_statistics_range(
         - period: The period used
         - start_time: The actual start time used
         - end_time: The actual end time used
-        - statistics: List of statistical data points with mean, min, max values
+        - statistics: List of data points, each with:
+          * start: Timestamp (milliseconds)
+          * end: Timestamp (milliseconds)
+          * mean: Average value in period
+          * min: Minimum value in period
+          * max: Maximum value in period
         - count: Number of statistical data points
 
     Examples:
-        entity_id="sensor.temperature", start_time="2024-10-23", period="hour"
-        entity_id="sensor.power", start_time="2024-01-01", end_time="2024-12-31", period="day"
+        entity_id="sensor.temperature", start_time="2024-10-01", end_time="2024-10-31", period="day"
+        entity_id="sensor.power", start_time="2024-01-01", end_time="2024-12-31", period="month"
         entity_id="sensor.humidity", start_time="yesterday", period="5minute"
 
-    Best Practices:
-        - Use this for accessing historical data beyond 10 days
-        - More token-efficient than get_history_range for large datasets
-        - Returns aggregated values (mean, min, max) instead of raw states
+    Pro Tip: If get_history_range returns a token error, use this tool with
+    the same date range to get the aggregated data instead.
     """
     logger.info(f"Getting statistics range for entity: {entity_id}, start: {start_time}, end: {end_time}, period: {period}")
 

--- a/app/server.py
+++ b/app/server.py
@@ -1307,6 +1307,150 @@ async def get_history_range(
         }
 
 @mcp.tool()
+@async_handler("get_statistics")
+async def get_statistics(
+    entity_id: str,
+    hours: int = 24,
+    period: str = "hour"
+) -> Dict[str, Any]:
+    """
+    Get statistical data for an entity for recent time period
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        hours: Number of hours of statistics to retrieve (default: 24)
+        period: Statistics period: "5minute", "hour", "day", "week", "month" (default: "hour")
+
+    Returns:
+        A dictionary containing:
+        - entity_id: The entity ID requested
+        - period: The period used
+        - statistics: List of statistical data points with mean, min, max values
+        - count: Number of statistical data points
+
+    Examples:
+        entity_id="sensor.temperature" - get 24h hourly statistics
+        entity_id="sensor.power_usage", hours=168, period="day" - get 7 days of daily stats
+        entity_id="sensor.humidity", hours=4, period="5minute" - get 4h of 5-minute stats
+
+    Best Practices:
+        - Use "5minute" period for recent data (< 10 days old)
+        - Use "hour" period for older data or long-term trends
+        - Token-efficient for large date ranges compared to raw states
+    """
+    logger.info(f"Getting statistics for entity: {entity_id}, hours: {hours}, period: {period}")
+
+    try:
+        from app.hass import get_entity_statistics
+
+        # Get statistics using the API function
+        stats_data = await get_entity_statistics(entity_id, hours, period)
+
+        # Check for errors from the API call
+        if isinstance(stats_data, dict) and "error" in stats_data:
+            return stats_data
+
+        # Extract statistics count
+        stats_list = stats_data.get("statistics", [])
+
+        return {
+            "entity_id": entity_id,
+            "period": period,
+            "hours_requested": hours,
+            "statistics": stats_list,
+            "count": len(stats_list)
+        }
+    except Exception as e:
+        logger.error(f"Error getting statistics for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": f"Error retrieving statistics: {str(e)}",
+            "statistics": [],
+            "count": 0
+        }
+
+@mcp.tool()
+@async_handler("get_statistics_range")
+async def get_statistics_range(
+    entity_id: str,
+    start_time: str,
+    end_time: Optional[str] = None,
+    period: str = "hour"
+) -> Dict[str, Any]:
+    """
+    Get statistical data for an entity for a specific date/time range
+
+    Args:
+        entity_id: The entity ID to get statistics for
+        start_time: Start time (ISO 8601, date only, or 'yesterday'/'today')
+        end_time: End time (optional, defaults to 'now')
+        period: Statistics period: "5minute", "hour", "day", "week", "month" (default: "hour")
+
+    Returns:
+        A dictionary containing:
+        - entity_id: The entity ID requested
+        - period: The period used
+        - start_time: The actual start time used
+        - end_time: The actual end time used
+        - statistics: List of statistical data points with mean, min, max values
+        - count: Number of statistical data points
+
+    Examples:
+        entity_id="sensor.temperature", start_time="2024-10-23", period="hour"
+        entity_id="sensor.power", start_time="2024-01-01", end_time="2024-12-31", period="day"
+        entity_id="sensor.humidity", start_time="yesterday", period="5minute"
+
+    Best Practices:
+        - Use this for accessing historical data beyond 10 days
+        - More token-efficient than get_history_range for large datasets
+        - Returns aggregated values (mean, min, max) instead of raw states
+    """
+    logger.info(f"Getting statistics range for entity: {entity_id}, start: {start_time}, end: {end_time}, period: {period}")
+
+    try:
+        from app.hass import get_entity_statistics_range
+
+        # Get statistics using the API function
+        stats_data = await get_entity_statistics_range(entity_id, start_time, end_time, period)
+
+        # Check for errors from the API call
+        if isinstance(stats_data, dict) and "error" in stats_data:
+            return stats_data
+
+        # Extract statistics count
+        stats_list = stats_data.get("statistics", [])
+
+        return {
+            "entity_id": entity_id,
+            "period": period,
+            "start_time": stats_data.get("start_time", start_time),
+            "end_time": stats_data.get("end_time", end_time or "now"),
+            "statistics": stats_list,
+            "count": len(stats_list)
+        }
+    except ValueError as e:
+        # Handle date parsing errors
+        logger.error(f"Date parsing error for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": str(e),
+            "statistics": [],
+            "count": 0,
+            "start_time": start_time,
+            "end_time": end_time or "now"
+        }
+    except Exception as e:
+        logger.error(f"Error getting statistics range for {entity_id}: {str(e)}")
+        return {
+            "entity_id": entity_id,
+            "error": f"Error retrieving statistics: {str(e)}",
+            "statistics": [],
+            "count": 0,
+            "start_time": start_time,
+            "end_time": end_time or "now"
+        }
+
+@mcp.tool()
 @async_handler("get_error_log")
 async def get_error_log() -> Dict[str, Any]:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.13"
 dependencies = [
     "mcp[cli]>=1.4.1",
     "httpx>=0.27.0",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,21 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "hass-mcp"
-version = "0.1.1"
-description = "Home Assistant Model Context Protocol (MCP) server"
+name = "hass-mcp-plus"
+version = "0.2.0"
+description = "Home Assistant Model Context Protocol (MCP) server - Enhanced fork with automation traces and improved token efficiency"
 readme = "README.md"
 requires-python = ">=3.13"
+license = {text = "MIT"}
+keywords = ["home-assistant", "mcp", "model-context-protocol", "claude", "llm", "smart-home"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Home Automation",
+]
+
 dependencies = [
     "mcp[cli]>=1.4.1",
     "httpx>=0.27.0",
@@ -21,8 +31,13 @@ test = [
 ]
 
 [project.scripts]
-hass-mcp = "app.run:main"
+hass-mcp-plus = "app.run:main"
 test = "pytest:main"
+
+[project.urls]
+Homepage = "https://github.com/rmaher001/hass-mcp-plus"
+Repository = "https://github.com/rmaher001/hass-mcp-plus"
+Issues = "https://github.com/rmaher001/hass-mcp-plus/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,6 @@ def mock_config():
     return {
         "hass_url": "http://localhost:8123",
         "hass_token": "mock_token",
-        "config_dir": "/Users/matt/Developer/hass-mcp/config",
+        "config_dir": "/tmp/hass-mcp-plus-test/config",
         "log_level": "INFO"
     }

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,14 @@
 version = 1
-revision = 1
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -19,18 +19,18 @@ dependencies = [
     { name = "idna" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126, upload-time = "2025-01-05T13:13:11.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041, upload-time = "2025-01-05T13:13:07.985Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
 ]
 
 [[package]]
@@ -40,36 +40,37 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418, upload-time = "2022-09-25T15:40:01.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259, upload-time = "2022-09-25T15:39:59.68Z" },
 ]
 
 [[package]]
 name = "hass-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -84,6 +85,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.4.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+    { name = "websockets", specifier = ">=12.0" },
 ]
 provides-extras = ["test"]
 
@@ -95,9 +97,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196, upload-time = "2024-11-15T12:30:47.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551, upload-time = "2024-11-15T12:30:45.782Z" },
 ]
 
 [[package]]
@@ -110,36 +112,36 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "httpx-sse"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload-time = "2023-01-07T11:08:11.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload-time = "2023-01-07T11:08:09.864Z" },
 ]
 
 [[package]]
@@ -149,9 +151,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
@@ -168,9 +170,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/cc/5c5bb19f1a0f8f89a95e25cb608b0b07009e81fd4b031e519335404e1422/mcp-1.4.1.tar.gz", hash = "sha256:b9655d2de6313f9d55a7d1df62b3c3fe27a530100cc85bf23729145b0dba4c7a", size = 154942 }
+sdist = { url = "https://files.pythonhosted.org/packages/50/cc/5c5bb19f1a0f8f89a95e25cb608b0b07009e81fd4b031e519335404e1422/mcp-1.4.1.tar.gz", hash = "sha256:b9655d2de6313f9d55a7d1df62b3c3fe27a530100cc85bf23729145b0dba4c7a", size = 154942, upload-time = "2025-03-14T09:52:15.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/0e/885f156ade60108e67bf044fada5269da68e29d758a10b0c513f4d85dd76/mcp-1.4.1-py3-none-any.whl", hash = "sha256:a7716b1ec1c054e76f49806f7d96113b99fc1166fc9244c2c6f19867cb75b593", size = 72448 },
+    { url = "https://files.pythonhosted.org/packages/e8/0e/885f156ade60108e67bf044fada5269da68e29d758a10b0c513f4d85dd76/mcp-1.4.1-py3-none-any.whl", hash = "sha256:a7716b1ec1c054e76f49806f7d96113b99fc1166fc9244c2c6f19867cb75b593", size = 72448, upload-time = "2025-03-14T09:52:13.669Z" },
 ]
 
 [package.optional-dependencies]
@@ -183,27 +185,27 @@ cli = [
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
 ]
 
 [[package]]
@@ -215,9 +217,9 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681, upload-time = "2025-01-24T01:42:12.693Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696, upload-time = "2025-01-24T01:42:10.371Z" },
 ]
 
 [[package]]
@@ -227,22 +229,22 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443, upload-time = "2024-12-18T11:31:54.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709, upload-time = "2024-12-18T11:29:03.193Z" },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273, upload-time = "2024-12-18T11:29:05.306Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027, upload-time = "2024-12-18T11:29:07.294Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888, upload-time = "2024-12-18T11:29:09.249Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738, upload-time = "2024-12-18T11:29:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138, upload-time = "2024-12-18T11:29:16.396Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025, upload-time = "2024-12-18T11:29:20.25Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633, upload-time = "2024-12-18T11:29:23.877Z" },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404, upload-time = "2024-12-18T11:29:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130, upload-time = "2024-12-18T11:29:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946, upload-time = "2024-12-18T11:29:31.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387, upload-time = "2024-12-18T11:29:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453, upload-time = "2024-12-18T11:29:35.533Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186, upload-time = "2024-12-18T11:29:37.649Z" },
 ]
 
 [[package]]
@@ -253,18 +255,18 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550, upload-time = "2025-02-27T10:10:32.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839, upload-time = "2025-02-27T10:10:30.711Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
 ]
 
 [[package]]
@@ -277,9 +279,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
 ]
 
 [[package]]
@@ -289,18 +291,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
 ]
 
 [[package]]
@@ -311,27 +313,27 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload-time = "2024-11-01T16:43:55.817Z" },
 ]
 
 [[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -342,9 +344,9 @@ dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376, upload-time = "2024-12-25T09:09:30.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120, upload-time = "2024-12-25T09:09:26.761Z" },
 ]
 
 [[package]]
@@ -354,9 +356,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102 }
+sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102, upload-time = "2025-03-08T10:55:34.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995 },
+    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995, upload-time = "2025-03-08T10:55:32.662Z" },
 ]
 
 [[package]]
@@ -369,18 +371,18 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711, upload-time = "2025-02-27T19:17:34.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061, upload-time = "2025-02-27T19:17:32.111Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
 ]
 
 [[package]]
@@ -391,7 +393,27 @@ dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568, upload-time = "2024-12-15T13:33:30.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315, upload-time = "2024-12-15T13:33:27.467Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]


### PR DESCRIPTION
## Summary

Adds WebSocket-based statistics API support and date range queries for accessing Home Assistant historical data.

## Changes

- Add WebSocket API client for Home Assistant statistics endpoints
- Add `get_statistics` and `get_statistics_range` tools for aggregated time-series data
- Add `get_history_range` tool for querying raw history by date/time range
- Support multiple date formats and HA aggregation granularity
- Fix TypeError in `get_entity_state` by adding missing `use_cache` parameter

## Use Cases

- Access historical data beyond default retention periods
- Query aggregated statistics to avoid large response payloads
- Perform date-specific historical analysis