### PR TITLE
Add error log filtering capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ Thumbs.db
 
 # Testing
 .pytest_cache/
+
+# Claude
+.claude/settings.local.json
+
+# uv
+uv.lock

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Hass-MCP enables AI assistants like Claude to interact directly with your Home A
 - **Automation Support**: List and control automations
 - **Guided Conversations**: Use prompts for common tasks like creating automations
 - **Smart Search**: Find entities by name, type, or state
+- **Advanced Error Log Filtering**: Filter logs by level, integration, keywords, or line limit for efficient troubleshooting
 - **Token Efficiency**: Lean JSON responses to minimize token usage
 
 ## Installation
@@ -167,6 +168,9 @@ Here are some examples of prompts you can use with Claude once Hass-MCP is set u
 - "Create an automation that turns on the lights at sunset"
 - "Help me troubleshoot why my bedroom motion sensor automation isn't working"
 - "Search for entities related to my living room"
+- "Show me the last 50 error log entries"
+- "Get MQTT integration errors from the log"
+- "Find all warnings containing 'timeout' in the error log"
 
 ## Available Tools
 
@@ -182,7 +186,25 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `call_service_tool`: Call any Home Assistant service
 - `restart_ha`: Restart Home Assistant
 - `get_history`: Get the state history of an entity
-- `get_error_log`: Get the Home Assistant error log
+- `get_error_log`: Get the Home Assistant error log with optional filtering by level, integration, search term, or line limit
+
+### Error Log Filtering
+
+The `get_error_log` tool supports advanced filtering to help you efficiently troubleshoot issues:
+
+**Filter Parameters:**
+- `level`: Filter by log level (ERROR, WARNING, INFO, DEBUG)
+- `integration`: Filter by integration name (e.g., 'mqtt', 'zwave', 'homeassistant')
+- `search_term`: Filter by keyword or phrase (case-insensitive)
+- `lines`: Limit number of lines returned (returns most recent N lines)
+
+**Filter Examples:**
+- `level="ERROR"` - Show only error entries
+- `integration="mqtt", lines=50` - Get last 50 MQTT integration log entries
+- `search_term="timeout", level="WARNING"` - Get warnings containing "timeout"
+- `lines=100` - Get last 100 log entries
+
+Filters can be combined for more precise results, improving token efficiency by returning only relevant log data.
 
 ## Prompts for Guided Conversations
 

--- a/app/hass.py
+++ b/app/hass.py
@@ -439,49 +439,107 @@ async def restart_home_assistant() -> Dict[str, Any]:
     return await call_service("homeassistant", "restart", {})
 
 @handle_api_errors
-async def get_hass_error_log() -> Dict[str, Any]:
+async def get_hass_error_log(
+    level: Optional[str] = None,
+    integration: Optional[str] = None,
+    search_term: Optional[str] = None,
+    lines: Optional[int] = None
+) -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting with optional filtering
+
+    Args:
+        level: Filter by log level (ERROR, WARNING, INFO, DEBUG, etc.)
+        integration: Filter by integration name (e.g., 'mqtt', 'zwave')
+        search_term: Filter by keyword or phrase
+        lines: Limit number of lines returned (most recent lines)
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
+        - log_text: The filtered log text
         - error_count: Number of ERROR entries found
         - warning_count: Number of WARNING entries found
         - integration_mentions: Map of integration names to mention counts
+        - total_lines: Total number of lines in filtered log
+        - filters_applied: Dictionary of filters that were applied
         - error: Error message if retrieval failed
     """
     try:
         # Call the Home Assistant API error_log endpoint
         url = f"{HA_URL}/api/error_log"
         headers = get_ha_headers()
-        
+
         async with httpx.AsyncClient() as client:
             response = await client.get(url, headers=headers, timeout=30)
-            
+
             if response.status_code == 200:
                 log_text = response.text
-                
-                # Count errors and warnings
+
+                # Track which filters were applied
+                filters_applied = {}
+
+                # Apply filters
+                if level or integration or search_term:
+                    import re
+                    log_lines = log_text.split('\n')
+                    filtered_lines = []
+
+                    for line in log_lines:
+                        # Skip empty lines
+                        if not line.strip():
+                            continue
+
+                        # Apply level filter
+                        if level:
+                            filters_applied['level'] = level
+                            if level.upper() not in line:
+                                continue
+
+                        # Apply integration filter
+                        if integration:
+                            filters_applied['integration'] = integration
+                            # Look for [integration_name] pattern
+                            if f'[{integration.lower()}]' not in line.lower():
+                                continue
+
+                        # Apply search term filter
+                        if search_term:
+                            filters_applied['search_term'] = search_term
+                            if search_term.lower() not in line.lower():
+                                continue
+
+                        filtered_lines.append(line)
+
+                    log_text = '\n'.join(filtered_lines)
+
+                # Apply line limit (get last N lines)
+                if lines and lines > 0:
+                    filters_applied['lines'] = lines
+                    log_lines = log_text.split('\n')
+                    log_text = '\n'.join(log_lines[-lines:])
+
+                # Count errors and warnings in the filtered log
                 error_count = log_text.count("ERROR")
                 warning_count = log_text.count("WARNING")
-                
-                # Extract integration mentions
+
+                # Extract integration mentions from filtered log
                 import re
                 integration_mentions = {}
-                
+
                 # Look for patterns like [mqtt], [zwave], etc.
                 for match in re.finditer(r'\[([a-zA-Z0-9_]+)\]', log_text):
-                    integration = match.group(1).lower()
-                    if integration not in integration_mentions:
-                        integration_mentions[integration] = 0
-                    integration_mentions[integration] += 1
-                
+                    integration_name = match.group(1).lower()
+                    if integration_name not in integration_mentions:
+                        integration_mentions[integration_name] = 0
+                    integration_mentions[integration_name] += 1
+
                 return {
                     "log_text": log_text,
                     "error_count": error_count,
                     "warning_count": warning_count,
-                    "integration_mentions": integration_mentions
+                    "integration_mentions": integration_mentions,
+                    "total_lines": len(log_text.split('\n')) if log_text else 0,
+                    "filters_applied": filters_applied if filters_applied else None
                 }
             else:
                 return {
@@ -490,7 +548,9 @@ async def get_hass_error_log() -> Dict[str, Any]:
                     "log_text": "",
                     "error_count": 0,
                     "warning_count": 0,
-                    "integration_mentions": {}
+                    "integration_mentions": {},
+                    "total_lines": 0,
+                    "filters_applied": None
                 }
     except Exception as e:
         logger.error(f"Error retrieving Home Assistant error log: {str(e)}")
@@ -499,7 +559,9 @@ async def get_hass_error_log() -> Dict[str, Any]:
             "log_text": "",
             "error_count": 0,
             "warning_count": 0,
-            "integration_mentions": {}
+            "integration_mentions": {},
+            "total_lines": 0,
+            "filters_applied": None
         }
 
 @handle_api_errors

--- a/app/server.py
+++ b/app/server.py
@@ -1204,25 +1204,60 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
 
 @mcp.tool()
 @async_handler("get_error_log")
-async def get_error_log() -> Dict[str, Any]:
+async def get_error_log(
+    level: Optional[str] = None,
+    integration: Optional[str] = None,
+    search_term: Optional[str] = None,
+    lines: Optional[int] = None
+) -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting with optional filtering
+
+    Args:
+        level: Filter by log level (ERROR, WARNING, INFO, DEBUG, etc.)
+        integration: Filter by integration name (e.g., 'mqtt', 'zwave', 'homeassistant')
+        search_term: Filter by keyword or phrase (case-insensitive)
+        lines: Limit number of lines returned (returns most recent N lines)
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
-        - error_count: Number of ERROR entries found
-        - warning_count: Number of WARNING entries found
+        - log_text: The filtered log text
+        - error_count: Number of ERROR entries found in filtered log
+        - warning_count: Number of WARNING entries found in filtered log
         - integration_mentions: Map of integration names to mention counts
+        - total_lines: Total number of lines in filtered log
+        - filters_applied: Dictionary showing which filters were applied
         - error: Error message if retrieval failed
-        
+
     Examples:
-        Returns errors, warnings count and integration mentions
+        level="ERROR" - get only error entries
+        integration="mqtt", lines=50 - get last 50 mqtt integration log entries
+        search_term="timeout", level="WARNING" - get warnings containing "timeout"
+        lines=100 - get last 100 log entries
+
     Best Practices:
-        - Use this tool when troubleshooting specific Home Assistant errors
+        - Use level="ERROR" to focus on critical issues
+        - Combine filters for more precise results (e.g., level + integration)
+        - Use lines parameter to limit output and reduce token usage
+        - Use search_term to find specific error messages or patterns
         - Look for patterns in repeated errors
         - Pay attention to timestamps to correlate errors with events
-        - Focus on integrations with many mentions in the log    
+        - Focus on integrations with many mentions in the log
     """
-    logger.info("Getting Home Assistant error log")
-    return await get_hass_error_log()
+    log_message = "Getting Home Assistant error log"
+    if level:
+        log_message += f" (level: {level})"
+    if integration:
+        log_message += f" (integration: {integration})"
+    if search_term:
+        log_message += f" (search: {search_term})"
+    if lines:
+        log_message += f" (lines: {lines})"
+
+    logger.info(log_message)
+    return await get_hass_error_log(
+        level=level,
+        integration=integration,
+        search_term=search_term,
+        lines=lines
+    )


### PR DESCRIPTION
## Summary
This PR adds advanced filtering capabilities to the `get_error_log` tool, making it easier to troubleshoot Home Assistant issues efficiently.

## Changes

### 1. Enhanced Error Log Filtering (app/hass.py, app/server.py)
Added four optional parameters to the `get_error_log` tool:
- `level`: Filter by log level (ERROR, WARNING, INFO, DEBUG)
- `integration`: Filter by integration name (e.g., 'mqtt', 'zwave')
- `search_term`: Filter by keyword or phrase (case-insensitive)
- `lines`: Limit number of lines returned (most recent N lines)

**Benefits:**
- Improves token efficiency by returning only relevant log data
- Filters can be combined for more precise results
- Makes troubleshooting faster and more targeted

**Example use cases:**
- `level="ERROR"` - Get only error entries
- `integration="mqtt", lines=50` - Get last 50 MQTT integration log entries
- `search_term="timeout", level="WARNING"` - Get warnings containing "timeout"

### 2. Updated .gitignore
- Added `.claude/settings.local.json` for Claude Code settings
- Added `uv.lock` to exclude environment-specific lock files

### 3. Updated README Documentation
- Added error log filtering to Features section
- Included usage examples demonstrating filtering capabilities
- Added dedicated Error Log Filtering section with parameters and examples

## Testing
The changes have been tested with various filter combinations to ensure proper filtering and response formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)