### PR TITLE
fix: wrap call_service_tool response in dict to fix Pydantic validation

### DIFF
--- a/app/hass.py
+++ b/app/hass.py
@@ -310,8 +310,12 @@ async def get_entities(
         return entities
 
 @handle_api_errors
-async def call_service(domain: str, service: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Call a Home Assistant service"""
+async def call_service(domain: str, service: str, data: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    """Call a Home Assistant service.
+
+    Returns:
+        List of affected entity states (may be empty for services like reload)
+    """
     if data is None:
         data = {}
     

--- a/app/server.py
+++ b/app/server.py
@@ -882,23 +882,29 @@ async def restart_ha() -> Dict[str, Any]:
 async def call_service_tool(domain: str, service: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """
     Call any Home Assistant service (low-level API access)
-    
+
     Args:
         domain: The domain of the service (e.g., 'light', 'switch', 'automation')
         service: The service to call (e.g., 'turn_on', 'turn_off', 'toggle')
         data: Optional data to pass to the service (e.g., {'entity_id': 'light.living_room'})
-    
+
     Returns:
-        The response from Home Assistant (usually empty for successful calls)
-    
+        A dictionary with success status and the list of affected entity states
+
     Examples:
         domain='light', service='turn_on', data={'entity_id': 'light.x', 'brightness': 255}
         domain='automation', service='reload'
         domain='fan', service='set_percentage', data={'entity_id': 'fan.x', 'percentage': 50}
-    
+
     """
     logger.info(f"Calling Home Assistant service: {domain}.{service} with data: {data}")
-    return await call_service(domain, service, data or {})
+    result = await call_service(domain, service, data or {})
+    return {
+        "success": True,
+        "domain": domain,
+        "service": service,
+        "affected_entities": result
+    }
 
 # Prompt functionality
 @mcp.prompt()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -303,3 +303,66 @@ class TestMCPServer:
             # Verify the function call with lean=True parameter
             mock_get_state.assert_called_with("light.living_room", lean=True)
             assert result == mock_filtered
+
+    @pytest.mark.asyncio
+    async def test_call_service_tool_returns_dict(self):
+        """Test that call_service_tool always returns a dictionary.
+
+        This is a regression test for issue #29 where call_service_tool
+        returned a raw list from the HA API, causing Pydantic validation errors.
+        """
+        from app.server import call_service_tool
+
+        with patch("app.server.call_service") as mock_call_service:
+            # Test with empty list response (e.g., automation.reload)
+            mock_call_service.return_value = []
+
+            result = await call_service_tool(domain="automation", service="reload")
+
+            assert isinstance(result, dict), "call_service_tool must return a dict"
+            assert result["success"] is True
+            assert result["domain"] == "automation"
+            assert result["service"] == "reload"
+            assert result["affected_entities"] == []
+
+            # Test with list of affected entities (e.g., light.turn_on)
+            mock_call_service.reset_mock()
+            mock_affected_entities = [
+                {"entity_id": "light.living_room", "state": "on"},
+                {"entity_id": "light.kitchen", "state": "on"}
+            ]
+            mock_call_service.return_value = mock_affected_entities
+
+            result = await call_service_tool(
+                domain="light",
+                service="turn_on",
+                data={"entity_id": "light.living_room"}
+            )
+
+            assert isinstance(result, dict), "call_service_tool must return a dict"
+            assert result["success"] is True
+            assert result["domain"] == "light"
+            assert result["service"] == "turn_on"
+            assert result["affected_entities"] == mock_affected_entities
+            assert len(result["affected_entities"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_call_service_tool_with_data(self):
+        """Test call_service_tool passes data correctly to the underlying service."""
+        from app.server import call_service_tool
+
+        with patch("app.server.call_service") as mock_call_service:
+            mock_call_service.return_value = [{"entity_id": "fan.bedroom", "state": "on"}]
+
+            result = await call_service_tool(
+                domain="fan",
+                service="set_percentage",
+                data={"entity_id": "fan.bedroom", "percentage": 50}
+            )
+
+            mock_call_service.assert_called_once_with(
+                "fan", "set_percentage", {"entity_id": "fan.bedroom", "percentage": 50}
+            )
+            assert result["success"] is True
+            assert result["domain"] == "fan"
+            assert result["service"] == "set_percentage"


### PR DESCRIPTION
## Summary

Fixes #29

The Home Assistant API returns a list of affected entity states for service calls (e.g., `[]` for `automation.reload`), but `call_service_tool` was passing this list directly as its return value. Since the function's return type annotation is `Dict[str, Any]`, this caused Pydantic validation errors:

```
Error executing tool call_service_tool: 1 validation error for call_service_toolOutput
result
  Input should be a valid dictionary [type=dict_type, input_value=[], input_type=list]
```

## Changes

- **app/hass.py**: Fix `call_service` return type annotation from `Dict[str, Any]` to `List[Dict[str, Any]]` to reflect actual HA API behavior
- **app/server.py**: Wrap `call_service_tool` result in a dict with `success`, `domain`, `service`, and `affected_entities` fields
- **tests/test_server.py**: Add regression tests for the fix

## New Response Format

Before:
```python
[]  # Raw list from HA API - causes validation error
```

After:
```python
{
    "success": True,
    "domain": "automation",
    "service": "reload",
    "affected_entities": []
}
```

## Test Plan

- [x] Added `test_call_service_tool_returns_dict` - verifies the tool always returns a dict
- [x] Added `test_call_service_tool_with_data` - verifies data is passed correctly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)