### PR TITLE
chore: tag-driven releases, OIDC publishing, :latest decoupling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ name: Docker Build & Push
 
 on:
   push:
+    branches: [master]
+    tags: ['v*']
   workflow_dispatch:
 
 env:
@@ -29,14 +31,16 @@ jobs:
           tags: |
             # Always include git sha for immutable references
             type=sha,format=long
-            # Set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            # :edge tracks master HEAD (use this to test unreleased changes)
+            type=raw,value=edge,enable={{is_default_branch}}
             # Tag branch builds (e.g. master)
             type=ref,event=branch
             # Full version numbers for exact versions
             type=semver,pattern={{version}}
             # Major.minor for API compatibility
             type=semver,pattern={{major}}.{{minor}}
+            # :latest tracks the most recent tagged release (NOT master HEAD)
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             # Major only for major version compatibility
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,9 +13,15 @@ jobs:
     name: Build and publish to PyPI
     needs: test
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -30,6 +36,4 @@ jobs:
         run: uv build
 
       - name: Publish to PyPI
-        run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version to release"
-        required: true
-        type: string
+  push:
+    tags: ['v*']
 
 permissions:
   contents: write
@@ -15,43 +11,26 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
-  create-release:
+  github-release:
     needs: test
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Validate version format
+      - name: Validate tag format
         run: |
-          echo "${{ github.event.inputs.version }}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
-            echo "Invalid version format. Use vX.Y.Z (e.g., v1.2.3)."
+          echo "${{ github.ref_name }}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "Invalid tag format. Use vX.Y.Z (e.g., v1.2.3)."
             exit 1
           }
 
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-      - name: Create and push Git tag
-        run: |
-          git tag ${{ github.event.inputs.version }}
-          git push origin ${{ github.event.inputs.version }}
-
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.event.inputs.version }} \
-            --title "${{ github.event.inputs.version }}" \
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
             --generate-notes \
-            --draft=false
-
-      - name: Trigger PyPI Publish
-        run: |
-          echo "PyPI publish will be triggered by the release event"
-
-      - name: Trigger Docker Build
-        run: |
-          echo "Docker build will be triggered by the tag push"
+            --repo "${{ github.repository }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] - 2025-08-05
+
+### Fixed
+- FastMCP initialization no longer passes the unsupported `capabilities` keyword (#19)
+
+## [0.1.0] - 2025-07-13
+
+Initial PyPI release.
+
+[Unreleased]: https://github.com/voska/hass-mcp/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/voska/hass-mcp/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/voska/hass-mcp/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "hass-mcp"
-version = "0.1.1"
+dynamic = ["version"]
 description = "Home Assistant Model Context Protocol (MCP) server"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -22,6 +22,9 @@ test = [
 [project.scripts]
 hass-mcp = "app.run:main"
 test = "pytest:main"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]


### PR DESCRIPTION
## Summary

Modernizes the release pipeline to current (2025–2026) Python OSS best practices:

- **Versioning from git tags** via `hatch-vcs` — no more hand-editing `pyproject.toml` before each release
- **PyPI trusted publishing (OIDC)** via `pypa/gh-action-pypi-publish` — replaces the long-lived `PYPI_API_TOKEN` secret with ephemeral OIDC tokens; auto-generates PEP 740 build provenance attestations
- **Tag-triggered releases** — `git push --tags` is now the entire release ceremony (no more `workflow_dispatch` UI step)
- **Docker `:latest` decoupling** — `:latest` now only updates on tagged releases. `:edge` tracks `master` HEAD for users who want to test unreleased changes. PR branches no longer push images.

## Why

Two production-safety wins:
1. `voska/hass-mcp:latest` used to update on every merge to `master`. Hundreds of users pull `:latest` per the README — every merge was effectively a release. Now `:latest` only moves on a tagged release.
2. PyPI API tokens are a long-lived credential. OIDC trusted publishing replaces them with short-lived tokens scoped per workflow, and gives us free supply-chain attestations.

## Changes

| File | What |
|---|---|
| `pyproject.toml` | `version = "0.1.1"` → `dynamic = ["version"]`; added `hatch-vcs` to build requires; new `[tool.hatch.version]` section |
| `.github/workflows/release.yml` | `workflow_dispatch` → triggers on tags `v*`; only creates the GitHub Release (PyPI + Docker cascade from that) |
| `.github/workflows/pypi.yml` | OIDC (`id-token: write` + `attestations: write`) + `pypa/gh-action-pypi-publish`; uses `pypi` environment; removed `UV_PUBLISH_TOKEN` |
| `.github/workflows/docker.yml` | Restricted triggers to `master` + tags; `:latest` only on tag, `:edge` for `master` HEAD |
| `CHANGELOG.md` | New — Keep-a-Changelog format with `[Unreleased]` section |

## One-time setup (already done)

- [x] PyPI Trusted Publisher configured (`voska/hass-mcp`, workflow `pypi.yml`, environment `pypi`)
- [x] GitHub Environment `pypi` created
- [x] Branch protection on `master` (require PR, require `Run Tests (3.13)` check)

## After merge

1. `git tag v0.1.2 && git push --tags` — validation release that exercises the new pipeline end-to-end with zero functional change (proves OIDC publish + hatch-vcs versioning + `:latest`-on-tag all work before relying on the flow for substantive releases)
2. Then layer in the MCP protocol test harness (separate PR)
3. Then triage the queued contributor PRs (#33, #34, #30, #36, #37/#38) against the harness
4. `git tag v0.2.0` for the first substantive release through the new flow

## Verification

- [x] `uv build` works locally; hatch-vcs produces `0.1.2.dev1+g716366b31...` from current git state
- [x] On tag push `vX.Y.Z`, hatch-vcs will produce a clean `X.Y.Z`
- [ ] CI green on this PR
- [ ] (After merge) Tagging `v0.1.2` produces a clean release end-to-end

## Notes for reviewer
- After this lands, the `PYPI_API_TOKEN` repo secret can be deleted (no longer used).