### PR TITLE
fix(docker): multi-stage build so hatch-vcs can read .git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Ignore version control files
-.git
+# .git is intentionally NOT excluded — hatch-vcs reads version from git tags
+# during the builder stage. The final runtime image (stage 2) does not carry .git.
 .gitignore
 
 # Ignore Docker and CI files
@@ -15,6 +16,10 @@ __pycache__
 .Python
 *.egg-info/
 *.egg
+
+# Ignore build artifacts
+dist/
+build/
 
 # Ignore environment and local files
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-# MCP server Dockerfile for Claude Desktop integration
+# Stage 1: build wheel (needs .git for hatch-vcs version derivation)
+FROM ghcr.io/astral-sh/uv:0.6.6-python3.13-bookworm AS builder
+
+WORKDIR /build
+COPY . .
+RUN uv build --wheel
+
+# Stage 2: runtime
 FROM ghcr.io/astral-sh/uv:0.6.6-python3.13-bookworm
 
-# Set working directory
 WORKDIR /app
 
-# Copy project files
-COPY . .
+COPY --from=builder /build/dist/*.whl /tmp/
+RUN uv pip install --system /tmp/*.whl && rm /tmp/*.whl
 
-# Set environment for MCP communication
 ENV PYTHONUNBUFFERED=1
-ENV PYTHONPATH=/app
 
-# Install package with UV (using --system flag)
-RUN uv pip install --system -e .
-
-# Run the MCP server with stdio communication using the module directly
 ENTRYPOINT ["python", "-m", "app"]


### PR DESCRIPTION
## Problem

After #41 merged, the docker build on master failed:
```
LookupError: Error getting the version from source `vcs`: setuptools-scm
was unable to detect version for /app.
```

`.dockerignore` excluded `.git`, but the new `dynamic = ["version"]` via `hatch-vcs` needs it to derive the version from tags.

Run that failed: https://github.com/voska/hass-mcp/actions/runs/25971899510

## Fix

Multi-stage Dockerfile:
- **Stage 1 (builder)**: keeps `.git`, runs `uv build --wheel` to produce the package
- **Stage 2 (runtime)**: copies only the built wheel, installs it, no git history in final image

Also added `dist/` and `build/` to `.dockerignore` so stale local build artifacts don't pollute the docker context.

## Tested locally (this time, for real)

```
$ docker build -t hass-mcp-test .
✅ builds successfully

$ docker run --rm --entrypoint python hass-mcp-test \
    -c "import importlib.metadata; print(importlib.metadata.version('hass-mcp'))"
0.1.2.dev2+gf442a68f8.d20260516

$ docker run --rm --entrypoint python hass-mcp-test \
    -c "from app.server import mcp; print(mcp.name)"
Hass-MCP

$ docker run --rm --entrypoint /bin/sh hass-mcp-test \
    -c "ls /app/.git 2>&1 || echo 'no .git - correct'"
no .git - correct
```