### PR TITLE
fix(prompts): use 'user' role instead of invalid 'system'

### DIFF
--- a/app/server.py
+++ b/app/server.py
@@ -943,7 +943,7 @@ You'll guide the user through creating an automation with the following steps:
     
     # Return the conversation starter messages
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -972,7 +972,7 @@ You'll help the user diagnose problems with their automation by checking:
     user_message = f"My automation {automation_id} isn't working properly. Can you help me troubleshoot it?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -1002,7 +1002,7 @@ You'll help the user diagnose problems with their entity by checking:
     user_message = f"My entity {entity_id} isn't working properly. Can you help me troubleshoot it?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -1030,7 +1030,7 @@ You'll help the user analyze their usage patterns and create optimized routines 
     user_message = "I'd like to optimize my home automations based on my actual usage patterns. Can you help analyze how I use my smart home and suggest better routines?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -1059,7 +1059,7 @@ You'll help the user perform a comprehensive audit of their automations by:
     user_message = "I'd like to do a health check on all my Home Assistant automations. Can you help me review them for conflicts, redundancies, and potential improvements?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -1087,7 +1087,7 @@ You'll help the user audit and improve their entity naming by:
     user_message = "I'd like to make my Home Assistant entity names more consistent and organized. Can you help me audit my current naming conventions and suggest improvements?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 
@@ -1116,7 +1116,7 @@ You'll help the user create optimized dashboards by:
     user_message = "I'd like to redesign my Home Assistant dashboards to be more functional and user-friendly. Can you help me create optimized layouts based on how I actually use my system?"
     
     return [
-        {"role": "system", "content": system_message},
+        {"role": "user", "content": system_message},
         {"role": "user", "content": user_message}
     ]
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -109,10 +109,6 @@ PROMPT_ARGS = {
 }
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="prompts currently return role='system' which the MCP spec rejects",
-)
 async def test_all_prompts_use_valid_roles():
     """Every prompt message must have role in {user, assistant} per MCP spec."""
     async with create_connected_server_and_client_session(


### PR DESCRIPTION
## Summary

Fixes #35. All 7 prompts in this server returned a leading message with `role='system'`, but the MCP `PromptMessage` schema accepts only `'user'` or `'assistant'`. Calling any prompt through a real MCP client (Claude Desktop, Claude Code, etc.) produced:

```
ValueError: Could not convert prompt result to message:
{'role': 'system', 'content': "You are an automation creation assistant..."}
```

Reported by multiple users; affected every prompt this server ships.

## Change

`role: 'system'` → `role: 'user'` in all 7 prompts in `app/server.py`. Content unchanged. The framing message now reads as the user setting context before the request — the canonical pattern for MCP prompts.

Single sed-style replacement; 7 occurrences updated, all in adjacent `return [...]` blocks.

## Test

The MCP protocol harness landed in #44 already had a detector for this bug, marked `@pytest.mark.xfail(strict=True)`. With the fix in place:

```
$ pytest tests/test_protocol.py::test_all_prompts_use_valid_roles
PASSED   (was XFAIL on master)
```

`strict=True` was deliberate — when the bug got fixed, the test transitioned XFAIL → XPASS and failed CI until the marker was removed. This PR removes the marker so the test becomes a normal regression test. Future re-introduction of `role='system'` (e.g. via a copy-paste from one prompt to another) will be caught immediately.

## Verification

```
$ uv run pytest tests/ -v
...
test_all_prompts_use_valid_roles                                  PASSED
test_call_service_tool_returns_dict_for_empty_list                XFAIL  (Issue #29, unrelated)
...
= 25 passed, 1 xfailed in 0.24s =
```

No other behavior changes.