### PR TITLE
fix(error_log): support HA OS / Supervised installations

### DIFF
--- a/app/hass.py
+++ b/app/hass.py
@@ -455,47 +455,60 @@ async def get_hass_error_log() -> Dict[str, Any]:
         - integration_mentions: Map of integration names to mention counts
         - error: Error message if retrieval failed
     """
+    import re
+
+    ansi_pattern = re.compile(r'\x1b\[[0-9;]*m')
+
+    def parse_log_text(log_text: str) -> Dict[str, Any]:
+        # HA OS logs include ANSI color codes that distort ERROR/WARNING counts
+        # and contaminate the returned text.
+        clean_text = ansi_pattern.sub('', log_text)
+
+        error_count = clean_text.count("ERROR")
+        warning_count = clean_text.count("WARNING")
+
+        integration_mentions: Dict[str, int] = {}
+        for match in re.finditer(r'\[([a-zA-Z0-9_\.]+)\]', clean_text):
+            integration = match.group(1).lower()
+            # Collapse homeassistant.components.X to X
+            if integration.startswith('homeassistant.components.'):
+                integration = integration.split('.')[-1]
+            integration_mentions[integration] = integration_mentions.get(integration, 0) + 1
+
+        return {
+            "log_text": clean_text,
+            "error_count": error_count,
+            "warning_count": warning_count,
+            "integration_mentions": integration_mentions,
+        }
+
     try:
-        # Call the Home Assistant API error_log endpoint
-        url = f"{HA_URL}/api/error_log"
         headers = get_ha_headers()
-        
+
         async with httpx.AsyncClient() as client:
-            response = await client.get(url, headers=headers, timeout=30)
-            
+            # HA OS / Supervised — the most common deployment — exposes Core
+            # logs at /api/hassio/core/logs. /api/error_log returns 404 there.
+            hassio_url = f"{HA_URL}/api/hassio/core/logs"
+            response = await client.get(hassio_url, headers=headers, timeout=30)
+
             if response.status_code == 200:
-                log_text = response.text
-                
-                # Count errors and warnings
-                error_count = log_text.count("ERROR")
-                warning_count = log_text.count("WARNING")
-                
-                # Extract integration mentions
-                import re
-                integration_mentions = {}
-                
-                # Look for patterns like [mqtt], [zwave], etc.
-                for match in re.finditer(r'\[([a-zA-Z0-9_]+)\]', log_text):
-                    integration = match.group(1).lower()
-                    if integration not in integration_mentions:
-                        integration_mentions[integration] = 0
-                    integration_mentions[integration] += 1
-                
-                return {
-                    "log_text": log_text,
-                    "error_count": error_count,
-                    "warning_count": warning_count,
-                    "integration_mentions": integration_mentions
-                }
-            else:
-                return {
-                    "error": f"Error retrieving error log: {response.status_code} {response.reason_phrase}",
-                    "details": response.text,
-                    "log_text": "",
-                    "error_count": 0,
-                    "warning_count": 0,
-                    "integration_mentions": {}
-                }
+                return parse_log_text(response.text)
+
+            # Fall back to standalone Home Assistant.
+            standalone_url = f"{HA_URL}/api/error_log"
+            response = await client.get(standalone_url, headers=headers, timeout=30)
+
+            if response.status_code == 200:
+                return parse_log_text(response.text)
+
+            return {
+                "error": f"Error retrieving error log: {response.status_code} {response.reason_phrase}",
+                "details": "Neither /api/hassio/core/logs nor /api/error_log are available",
+                "log_text": "",
+                "error_count": 0,
+                "warning_count": 0,
+                "integration_mentions": {},
+            }
     except Exception as e:
         logger.error(f"Error retrieving Home Assistant error log: {str(e)}")
         return {

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -178,3 +178,56 @@ async def test_get_entity_via_protocol():
         )
         assert not result.isError
         assert "on" in result.content[0].text
+
+
+@respx.mock
+async def test_get_error_log_uses_hassio_endpoint_on_ha_os():
+    """HA OS / Supervised exposes Core logs at /api/hassio/core/logs; the
+    standalone /api/error_log endpoint returns 404 there. get_error_log must
+    try the hassio endpoint first."""
+    import json
+
+    respx.get("http://localhost:8123/api/hassio/core/logs").mock(
+        return_value=httpx.Response(
+            200,
+            text="2026-05-16 12:00:00 ERROR (MainThread) [mqtt] connection lost\n"
+                 "2026-05-16 12:00:01 WARNING (MainThread) [zwave] retrying\n",
+        )
+    )
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool("get_error_log", arguments={})
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["error_count"] == 1
+        assert payload["warning_count"] == 1
+        assert payload["integration_mentions"]["mqtt"] == 1
+        assert payload["integration_mentions"]["zwave"] == 1
+
+
+@respx.mock
+async def test_get_error_log_falls_back_to_standalone_endpoint():
+    """When /api/hassio/core/logs is unavailable (standalone Home Assistant
+    install), get_error_log must fall back to /api/error_log."""
+    import json
+
+    respx.get("http://localhost:8123/api/hassio/core/logs").mock(
+        return_value=httpx.Response(404, text="Not Found")
+    )
+    # ANSI color codes are stripped from the parsed output and excluded from counts.
+    respx.get("http://localhost:8123/api/error_log").mock(
+        return_value=httpx.Response(
+            200,
+            text="\x1b[31mERROR\x1b[0m [homeassistant.components.light] failed\n",
+        )
+    )
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool("get_error_log", arguments={})
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert "\x1b[" not in payload["log_text"], "ANSI codes must be stripped"
+        assert payload["error_count"] == 1
+        assert payload["integration_mentions"]["light"] == 1


### PR DESCRIPTION
## Summary

Supersedes #37 (@darinlarimore) and #38 (@JoeKarlsson). Preserves Joe's more-complete approach with `Co-Authored-By` attribution; Darin independently identified the same root cause.

The `/api/error_log` endpoint returns **404 on Home Assistant OS / Supervised** installs (the most common deployment target). Those installs expose Core logs at `/api/hassio/core/logs` via the Supervisor. Users running hass-mcp against `http://supervisor/core` or as an HA add-on couldn't use `get_error_log` at all.

## Change

`app/hass.py::get_hass_error_log`:

1. **Try `/api/hassio/core/logs` first** (HA OS / Supervised), fall back to `/api/error_log` (standalone). HA OS is more common, so this is also fewer requests on the common path.
2. **Strip ANSI color codes** from the response — HA OS includes them and they otherwise distort ERROR/WARNING counts and contaminate the returned `log_text`.
3. **Collapse `homeassistant.components.X` integration labels to `X`** in the mention map. Without this, `[homeassistant.components.mqtt]` and `[mqtt]` were counted as different integrations.
4. **Extract parsing into an inner helper** (`parse_log_text`) so the success path is identical regardless of which endpoint provided the text.

## Tests

Two new protocol-level tests in `tests/test_protocol.py`:

| Test | Verifies |
|---|---|
| `test_get_error_log_uses_hassio_endpoint_on_ha_os` | HA OS path: `/api/hassio/core/logs` returns parsed stats |
| `test_get_error_log_falls_back_to_standalone_endpoint` | When hassio endpoint 404s, falls back to `/api/error_log`; ANSI is stripped; `homeassistant.components.X` is collapsed |

```
$ uv run pytest tests/
= 30 passed in 0.29s =
```

(was: 28 passed before this PR — net +2 tests, no regressions.)

## Credit

Approach and core diff are @JoeKarlsson's from #38; he gets the `Co-Authored-By` trailer. Tests are new — neither #37 nor #38 included regression tests, which is now possible thanks to the protocol harness landed in #44. Both PRs can be closed as superseded.