### PR TITLE
ci: sync README.md to Docker Hub repo overview

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,30 @@
+name: Sync Docker Hub Description
+
+# Mirrors README.md to the Docker Hub repository overview so the page at
+# https://hub.docker.com/r/voska/hass-mcp matches what's on GitHub.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: voska/hass-mcp
+          short-description: "Home Assistant MCP server — let Claude and other LLMs control your smart home"
+          readme-filepath: ./README.md


### PR DESCRIPTION
## What

New workflow `.github/workflows/dockerhub-description.yml` that mirrors `README.md` to the Docker Hub repository overview at https://hub.docker.com/r/voska/hass-mcp.

The Docker Hub page currently has no overview, so users pulling the image have no inline context — they just see tag list and have to bounce to GitHub. README.md already has the install instructions and feature list, so syncing it is the canonical move.

## Approach

Uses [peter-evans/dockerhub-description@v5](https://github.com/peter-evans/dockerhub-description) — Node 24, ~6M monthly downloads, the de facto choice for this. Triggers:

- `push` to `master` when `README.md` or this workflow changes (auto-resync)
- `workflow_dispatch` for manual one-shot syncs (needed for initial population since README isn't changing in this PR)

Short description set inline:

> Home Assistant MCP server — let Claude and other LLMs control your smart home

Reuses existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets already wired up for image push.

## Token scope check

The `DOCKERHUB_TOKEN` needs at least **Repository Read & Write** scope. It already works for `docker push` (image push to `voska/hass-mcp`), so this scope is met. If for some reason the token is restricted to image-push-only, the workflow will fail with a 403 and we'll know.

## After merge

Run once manually to populate the description:

```bash
gh workflow run dockerhub-description.yml --repo voska/hass-mcp
```

Then any future edit to `README.md` automatically updates the Docker Hub page.

## Verify

After the first run:
- https://hub.docker.com/r/voska/hass-mcp should show the README content as the overview
- Repository subtitle should read the short description above