### PR TITLE
feat(transport): streamable HTTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,50 @@ claude mcp add hass-mcp -e HA_URL=http://homeassistant.local:8123 -e HA_TOKEN=YO
 
 Replace `YOUR_LONG_LIVED_TOKEN` with your actual Home Assistant token and update the HA_URL to match your Home Assistant instance address.
 
+## HTTP Transport (Streamable)
+
+For deployments that can't use stdio — running behind an MCP gateway, hosting on Smithery, sharing one server across multiple clients, or connecting from network-based tools like LibreChat or OpenWebUI — Hass-MCP supports the MCP [streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports). The server runs in stateless mode (no `Mcp-Session-Id`, JSON responses), suitable for horizontally-scaled hosts.
+
+> [!CAUTION]
+> **HTTP mode exposes full Home Assistant control over the network.** Anyone who can reach the port can call any tool — turn off lights, unlock doors, trigger automations, restart HA. The MCP spec does not yet ship a built-in auth layer in this server. Until it does, you **must** put it behind one of:
+>
+> - A reverse proxy (nginx, Caddy, Traefik) doing basic-auth or bearer-token validation
+> - A VPN or zero-trust network (Tailscale, WireGuard, Cloudflare Access)
+> - Localhost binding only (the default — change `--host` only if you know what you're doing)
+>
+> Do not expose `:8000` to the open internet without auth.
+
+### Running locally
+
+**Using uvx:**
+
+```bash
+HA_URL=http://homeassistant.local:8123 \
+HA_TOKEN=YOUR_LONG_LIVED_TOKEN \
+uvx hass-mcp --http --port 8000
+```
+
+The server binds `127.0.0.1` by default. Override with `--host 0.0.0.0` only when you've also configured auth in front of it.
+
+### Running in Docker
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e HA_URL=http://homeassistant.local:8123 \
+  -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN \
+  voska/hass-mcp:latest --http --host 0.0.0.0 --port 8000
+```
+
+`--host 0.0.0.0` is required inside Docker so the port is reachable through the bridge. Bind the publish (`-p`) to `127.0.0.1:8000:8000` if you only want it reachable from the host, or put a reverse proxy in front.
+
+### Endpoint
+
+The MCP endpoint is at `/mcp`. Point your client at `http://<host>:<port>/mcp`.
+
+### Smithery / PaaS
+
+The server honors the `PORT` environment variable (Smithery's convention) in addition to `MCP_PORT`. Smithery deployment requires `--http` mode and reads `PORT` automatically.
+
 ## Usage Examples
 
 Here are some examples of prompts you can use with Claude once Hass-MCP is set up:

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python
-"""Entry point for running Hass-MCP as a module"""
+"""Entry point for `python -m app`. Delegates to app.run.main so both this
+and the `hass-mcp` console script (`[project.scripts]`) take the same CLI."""
 
-from app.server import mcp
-
-
-def main():
-    """Run the MCP server with stdio communication"""
-    mcp.run()
+from app.run import main
 
 
 if __name__ == "__main__":

--- a/app/run.py
+++ b/app/run.py
@@ -1,7 +1,36 @@
-"""Entry point for running Hass-MCP via uv/uvx tool"""
+"""Entry point for running Hass-MCP via uv/uvx tool."""
 
-from app.server import mcp
+import argparse
+import os
+
 
 def main():
-    """Run the MCP server with stdio communication"""
-    mcp.run()
+    """Run the MCP server. Defaults to stdio; pass --http for streamable HTTP."""
+    parser = argparse.ArgumentParser(prog="hass-mcp", description="Home Assistant MCP server")
+    parser.add_argument(
+        "--http",
+        action="store_true",
+        help="Run as streamable HTTP server instead of stdio (default: stdio)",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("MCP_HOST", "127.0.0.1"),
+        help="Host to bind when --http is set (default: 127.0.0.1; override with MCP_HOST)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("PORT", os.environ.get("MCP_PORT", "8000"))),
+        help="Port to bind when --http is set (default: 8000; override with PORT or MCP_PORT)",
+    )
+    args = parser.parse_args()
+
+    if args.http:
+        # The server module reads these at import time to configure FastMCP.
+        os.environ["MCP_TRANSPORT"] = "streamable-http"
+        os.environ["MCP_HOST"] = args.host
+        os.environ["MCP_PORT"] = str(args.port)
+
+    from app.server import mcp
+
+    mcp.run(transport=os.environ.get("MCP_TRANSPORT", "stdio"))

--- a/app/server.py
+++ b/app/server.py
@@ -25,10 +25,26 @@ from app.hass import (
 T = TypeVar('T')
 
 # Create an MCP server
+import os
+
 from mcp.server.fastmcp import FastMCP, Context, Image
-from mcp.server.stdio import stdio_server
 import mcp.types as types
-mcp = FastMCP("Hass-MCP")
+
+# When MCP_TRANSPORT is "streamable-http", configure for stateless operation
+# so the server works behind load balancers and on hosts like Smithery that
+# scale horizontally. Stateful mode is still the right default for local stdio.
+_http_mode = os.environ.get("MCP_TRANSPORT") == "streamable-http"
+
+mcp = FastMCP(
+    "Hass-MCP",
+    # Bind localhost by default. Override with MCP_HOST when running in Docker
+    # or behind a reverse proxy. PORT (without prefix) is honored for Smithery
+    # and other PaaS conventions.
+    host=os.environ.get("MCP_HOST", "127.0.0.1"),
+    port=int(os.environ.get("PORT", os.environ.get("MCP_PORT", "8000"))),
+    stateless_http=_http_mode,
+    json_response=_http_mode,
+)
 
 def async_handler(command_type: str):
     """

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,0 +1,175 @@
+"""
+Docker integration tests for hass-mcp.
+
+Builds the Dockerfile, then drives the resulting image through both transports
+end-to-end. Verifies the published image works the same way users will run it.
+
+Skipped automatically if docker isn't on PATH (e.g., CI runners without docker
+or local devs who don't have it installed).
+"""
+
+import asyncio
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamable_http_client
+
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(shutil.which("docker") is None, reason="docker not installed"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# Override conftest's autouse httpx mock so the MCP HTTP client uses real httpx.
+@pytest.fixture(autouse=True)
+def mock_get_client():
+    yield
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def docker_image():
+    """Build the Dockerfile once per test module; return the image tag."""
+    tag = f"hass-mcp-test:{uuid.uuid4().hex[:8]}"
+    result = subprocess.run(
+        ["docker", "build", "-t", tag, "."],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"docker build failed:\n{result.stdout}\n{result.stderr}")
+    yield tag
+    subprocess.run(["docker", "rmi", "-f", tag], capture_output=True)
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_http(url, timeout=20):
+    """Poll until the HTTP server responds (not just TCP accepts). The HTTP
+    handler may take longer to come up than the port — especially in Docker."""
+    import urllib.request
+    import urllib.error
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            # Any response from the MCP endpoint (even 4xx/405 for GET) means
+            # the HTTP handler is live.
+            urllib.request.urlopen(url, timeout=0.5)
+            return True
+        except urllib.error.HTTPError:
+            return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            time.sleep(0.2)
+    return False
+
+
+async def test_docker_image_version_metadata(docker_image):
+    """hatch-vcs produced a real version; the package installed cleanly."""
+    result = subprocess.run(
+        [
+            "docker", "run", "--rm", "--entrypoint", "python", docker_image,
+            "-c", "import importlib.metadata; print(importlib.metadata.version('hass-mcp'))",
+        ],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, result.stderr
+    version = result.stdout.strip()
+    # Either a clean release tag (X.Y.Z) or a dev version (X.Y.Z.devN+...)
+    assert version, "hass-mcp version is empty inside the image"
+    assert "." in version
+
+
+async def test_docker_image_excludes_git_directory(docker_image):
+    """Multi-stage build keeps .git only in the builder; the runtime image is clean."""
+    result = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "/bin/sh", docker_image,
+         "-c", "test ! -d /app/.git && echo OK"],
+        capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0 and result.stdout.strip() == "OK"
+
+
+async def test_docker_stdio_transport(docker_image):
+    """`docker run -i` with stdio is how Claude Desktop launches hass-mcp."""
+    params = StdioServerParameters(
+        command="docker",
+        args=[
+            "run", "-i", "--rm",
+            "-e", "HA_URL=http://localhost:8123",
+            "-e", "HA_TOKEN=docker-stdio-test",
+            docker_image,
+        ],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            init = await session.initialize()
+            assert init.serverInfo.name == "Hass-MCP"
+            tools = await session.list_tools()
+            assert len(tools.tools) == 12
+            prompts = await session.list_prompts()
+            assert len(prompts.prompts) == 7
+
+
+async def test_docker_streamable_http_transport(docker_image):
+    """`docker run --http` exposes streamable HTTP for standalone deployments."""
+    port = _free_port()
+    container = f"hass-mcp-http-{uuid.uuid4().hex[:8]}"
+    proc = subprocess.Popen(
+        [
+            "docker", "run", "--rm", "--name", container,
+            "-p", f"{port}:{port}",
+            "-e", "HA_URL=http://localhost:8123",
+            "-e", "HA_TOKEN=docker-http-test",
+            docker_image,
+            "--http", "--host", "0.0.0.0", "--port", str(port),
+        ],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    try:
+        assert _wait_for_http(f"http://127.0.0.1:{port}/mcp"), (
+            "Docker HTTP server failed to come up. "
+            f"docker logs: "
+            f"{subprocess.run(['docker', 'logs', container], capture_output=True, text=True).stderr}"
+        )
+
+        async with streamable_http_client(f"http://127.0.0.1:{port}/mcp") as (
+            read, write, _get_session_id,
+        ):
+            async with ClientSession(read, write) as session:
+                init = await session.initialize()
+                assert init.serverInfo.name == "Hass-MCP"
+                tools = await session.list_tools()
+                assert len(tools.tools) == 12
+
+                result = await session.call_tool("get_version", {})
+                assert not result.isError
+    finally:
+        subprocess.run(["docker", "stop", "--time", "2", container], capture_output=True)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -1,0 +1,227 @@
+"""
+Live transport tests for hass-mcp.
+
+These spawn the actual `python -m app` subprocess and drive it through the
+real MCP client transports (stdio and streamable HTTP). They verify the
+end-to-end wire protocol, not just in-memory behavior, and act as a
+regression net for the CLI entry point + transport configuration.
+
+Marked `slow` because each test spawns a subprocess and goes over a real
+transport. They take ~1-3 seconds each, which is fine but adds up.
+"""
+
+import asyncio
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamable_http_client
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# tests/conftest.py installs autouse fixtures that replace httpx.AsyncClient
+# with a MagicMock. Those leak into the MCP HTTP *client* too, breaking the
+# real-transport tests below. Override here so real httpx runs.
+@pytest.fixture(autouse=True)
+def mock_get_client():
+    yield
+
+
+SERVER_ENV = {
+    "HA_URL": "http://localhost:8123",
+    "HA_TOKEN": "transport-test-token",
+}
+
+
+EXPECTED_TOOLS = {
+    "call_service_tool",
+    "domain_summary_tool",
+    "entity_action",
+    "get_entity",
+    "get_error_log",
+    "get_history",
+    "get_version",
+    "list_automations",
+    "list_entities",
+    "restart_ha",
+    "search_entities_tool",
+    "system_overview",
+}
+
+EXPECTED_PROMPTS = {
+    "automation_health_check",
+    "create_automation",
+    "dashboard_layout_generator",
+    "debug_automation",
+    "entity_naming_consistency",
+    "routine_optimizer",
+    "troubleshoot_entity",
+}
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(host, port, timeout=10):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.25):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+async def _drive_session(session: ClientSession) -> None:
+    """Exercise the protocol surface common to every transport test."""
+    init = await session.initialize()
+    assert init.serverInfo.name == "Hass-MCP"
+    assert init.capabilities.tools is not None
+    assert init.capabilities.prompts is not None
+    assert init.capabilities.resources is not None
+
+    tools = await session.list_tools()
+    assert {t.name for t in tools.tools} == EXPECTED_TOOLS
+
+    prompts = await session.list_prompts()
+    assert {p.name for p in prompts.prompts} == EXPECTED_PROMPTS
+
+    # Prompt invocation roundtrip — regression for the role-validation bug class
+    result = await session.get_prompt("create_automation", {"trigger_type": "state"})
+    for msg in result.messages:
+        assert msg.role in ("user", "assistant")
+
+    # Tool invocation roundtrip — HA call will fail (no real HA), but the
+    # protocol path is what we're verifying.
+    result = await session.call_tool("get_version", {})
+    assert not result.isError
+
+
+# --- stdio transport --------------------------------------------------------
+
+async def test_stdio_transport_end_to_end():
+    """python -m app (stdio default) responds correctly to a real MCP client."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "app"],
+        env={**os.environ, **SERVER_ENV},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await _drive_session(session)
+
+
+# --- streamable HTTP transport ----------------------------------------------
+
+async def test_streamable_http_transport_end_to_end():
+    """python -m app --http exposes the server over streamable HTTP."""
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "app", "--http", "--port", str(port)],
+        env={**os.environ, **SERVER_ENV},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert _wait_for_port("127.0.0.1", port), (
+            f"HTTP server failed to bind on port {port}. "
+            f"stderr: {proc.stderr.read(2048).decode(errors='replace')}"
+        )
+
+        async with streamable_http_client(f"http://127.0.0.1:{port}/mcp") as (
+            read,
+            write,
+            get_session_id,
+        ):
+            async with ClientSession(read, write) as session:
+                await _drive_session(session)
+                # Stateless mode is configured for --http, so no session id.
+                assert get_session_id() is None
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+async def test_http_mode_binds_localhost_by_default():
+    """Default --http binding is 127.0.0.1; not reachable from another interface."""
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "app", "--http", "--port", str(port)],
+        env={**os.environ, **SERVER_ENV},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert _wait_for_port("127.0.0.1", port)
+        # Hitting via 127.0.0.1 works (just verified above).
+        # We can't portably assert "not reachable on 0.0.0.0" without raising
+        # platform-specific assumptions; verifying it bound localhost via the
+        # successful connect on 127.0.0.1 and the absence of a wildcard bind
+        # is sufficient here. The settings-level test below pins the default.
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# --- configuration / env var contract ---------------------------------------
+
+def test_default_settings_are_local_stdio_safe(monkeypatch):
+    """With no env vars, the FastMCP server defaults to localhost binding
+    and non-stateless mode (stdio shape). The streamable HTTP mode opts in
+    explicitly via MCP_TRANSPORT."""
+    for k in ("MCP_TRANSPORT", "MCP_HOST", "MCP_PORT", "PORT"):
+        monkeypatch.delenv(k, raising=False)
+    # Re-import to pick up env state at import time.
+    import importlib
+    import app.server as server_mod
+    importlib.reload(server_mod)
+    assert server_mod.mcp.settings.host == "127.0.0.1"
+    assert server_mod.mcp.settings.stateless_http is False
+
+
+def test_http_transport_env_enables_stateless(monkeypatch):
+    """Setting MCP_TRANSPORT=streamable-http enables stateless + json-response."""
+    monkeypatch.setenv("MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("MCP_PORT", "9999")
+    import importlib
+    import app.server as server_mod
+    importlib.reload(server_mod)
+    assert server_mod.mcp.settings.host == "127.0.0.1"
+    assert server_mod.mcp.settings.port == 9999
+    assert server_mod.mcp.settings.stateless_http is True
+    assert server_mod.mcp.settings.json_response is True
+
+
+def test_smithery_port_env_is_honored(monkeypatch):
+    """Smithery (and other PaaS) sets PORT without an MCP_ prefix."""
+    monkeypatch.setenv("MCP_TRANSPORT", "streamable-http")
+    monkeypatch.delenv("MCP_PORT", raising=False)
+    monkeypatch.setenv("PORT", "12345")
+    import importlib
+    import app.server as server_mod
+    importlib.reload(server_mod)
+    assert server_mod.mcp.settings.port == 12345


### PR DESCRIPTION
## Summary

Adds the [MCP streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports) alongside the existing stdio. Same entry point — `hass-mcp` (or `python -m app`) defaults to stdio; pass `--http` to run as a streamable HTTP server.

Closes #23 (the most-requested feature). Supersedes #33 with attribution to @robertlestak via `Co-Authored-By` trailer.

## Why now

Unlocks every "I want to run hass-mcp as a service" use case that was forcing users into stdio-bridge hacks:

- Sharing one server across multiple clients (Claude Desktop + Claude Code + Cursor on the same machine no longer need three Docker containers)
- Running behind MCP gateways (closes #39's class of problem)
- Hosting on Smithery or similar PaaS
- Integrating from network-based tools (LibreChat, OpenWebUI)

## What's in this PR

### Code (`app/`)

- **`app/server.py`** — reads `MCP_TRANSPORT`, `MCP_HOST`, `MCP_PORT`, `PORT` at import time and configures FastMCP. When `MCP_TRANSPORT=streamable-http`, enables `stateless_http=True` + `json_response=True` so the server works behind load balancers and on horizontally-scaled hosts (Smithery). Stdio retains stateful mode.
- **`app/run.py`** — `--http`, `--host`, `--port` CLI args; sets the env vars then imports `app.server` so the FastMCP instance picks them up. `mcp.run(transport=...)` dispatches.
- **`app/__main__.py`** — delegates to `app.run.main` so `python -m app` and `hass-mcp` (console script) share the same CLI.

### Defaults — chosen deliberately

| | |
|---|---|
| Default transport | **stdio** (no behavior change for existing users) |
| Default host | **`127.0.0.1`** — opt in to `--host 0.0.0.0` |
| Dockerfile `MCP_HOST=0.0.0.0` | **not set** (the dangerous combo with no auth) |
| `PORT` env var | honored for Smithery compat |
| Stateless / JSON response | enabled only when `--http` |

### Tests — real wire transports

**`tests/test_transports.py`** (6 tests, ~1.6s)
Spawns the actual `python -m app` subprocess for both transports and drives it through the real MCP client (`stdio_client`, `streamable_http_client`). Negotiates protocol `2025-11-25` over real stdio and real HTTP. Plus four config-level tests pinning the default-localhost and stateless-on-HTTP guarantees.

**`tests/test_docker.py`** (4 tests, ~5.5s)
Builds the Dockerfile and runs the same end-to-end drives against the built image:
- `test_docker_stdio_transport` — `docker run -i` (Claude Desktop's launch shape)
- `test_docker_streamable_http_transport` — `docker run --http`, real HTTP from outside the container
- `test_docker_image_version_metadata` — hatch-vcs produces a valid version inside the image
- `test_docker_image_excludes_git_directory` — multi-stage build keeps `.git` out of the runtime image

Skipped automatically when `docker` isn't on PATH.

### Docs (`README.md`)

New section explaining HTTP transport with a prominent `> [!CAUTION]` block on the auth gap. Lists canonical mitigations (reverse proxy with bearer-token / VPN / localhost-only) so users don't get cargo-culted into exposing port 8000 to the open internet.

## Verification

```
$ uv run pytest tests/ -v
...
40 passed in 7.05s
```

Includes 8 protocol tests (pre-existing harness), 6 new transport tests, 4 new Docker tests, and ~22 existing unit tests.

Manual end-to-end:
- `uvx hass-mcp` (stdio) — Claude Desktop reads tools/prompts ✓
- `uvx hass-mcp --http --port 8000` then `curl -X POST http://127.0.0.1:8000/mcp ...` — negotiates protocol `2025-11-25` ✓
- `docker run --rm -p 8000:8000 -e HA_URL=... -e HA_TOKEN=... voska/hass-mcp:edge --http --host 0.0.0.0 --port 8000` ✓

## Out of scope (deliberate follow-ups)

- **OAuth 2.1 token verification** — the canonical MCP auth mechanism per the `2025-11-25` spec. Real PR on its own (SDK ships `TokenVerifier` / `AuthSettings`; need to pick an issuer pattern). Until then, users put auth in front via reverse proxy or VPN — README documents this.
- **CORS middleware** — only needed when browser-based clients show up.
- **`Origin` header validation** — technically MUST per spec; FastMCP doesn't ship a config flag, would need custom middleware. Pair with the CORS work.
- **HA add-on packaging** — separate repo, gets the supervisor token for free; HA also ships its own `mcp_server` integration with a different scope.

## Credit

The shape of this PR (CLI flags, `mcp.run(transport=...)`) is the same approach @robertlestak proposed in #33 (Nov 2025). I rewrote against the current SDK (1.27.1 from this morning's #51 bump rather than the 1.9.0 his PR pinned), added tests and security defaults, and pulled the README into shape. His PR can be closed with thanks; he gets the `Co-Authored-By` trailer on the merge commit.