### PR TITLE
feat(areas): resolve entity areas via HA template API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Per-entity `area` field on `get_entity`, `list_entities`,
+  `search_entities_tool`, and `system_overview`. Areas are resolved
+  through HA's area registry (via `/api/template` with the
+  `area_name(entity_id)` Jinja helper), which automatically falls back
+  to the parent device's area when not set directly on the entity.
+- New `get_entities_by_area` tool — list everything in a given room.
+  Case-insensitive area match, optional domain filter.
+
+### Fixed
+- `system_overview` no longer reports every entity under a fake
+  "Unknown" area. The previous code read `attributes.area_id` from
+  `/api/states`, which HA never populates; entities without a real
+  area are now bucketed under "Unassigned" and entities with one show
+  their actual area name. ([#28])
+
 ## [0.3.0] - 2026-05-17
 
 ### Added
@@ -96,6 +112,7 @@ Initial PyPI release.
 
 [#19]: https://github.com/voska/hass-mcp/issues/19
 [#23]: https://github.com/voska/hass-mcp/issues/23
+[#28]: https://github.com/voska/hass-mcp/issues/28
 [#29]: https://github.com/voska/hass-mcp/issues/29
 [#33]: https://github.com/voska/hass-mcp/pull/33
 [#35]: https://github.com/voska/hass-mcp/issues/35

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Here are some examples of prompts you can use with Claude once Hass-MCP is set u
 
 - "What's the current state of my living room lights?"
 - "Turn off all the lights in the kitchen"
+- "What's the temperature in the master bedroom?"
+- "List everything in the guest room"
 - "List all my sensors that contain temperature data"
 - "Give me a summary of my climate entities"
 - "Create an automation that turns on the lights at sunset"
@@ -227,6 +229,7 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `restart_ha`: Restart Home Assistant
 - `get_history`: Get the state history of an entity
 - `get_error_log`: Get the Home Assistant error log
+- `get_entities_by_area`: List entities in a specific area / room
 
 ## Prompts for Guided Conversations
 

--- a/app/areas.py
+++ b/app/areas.py
@@ -1,0 +1,133 @@
+"""
+Per-entity area enrichment for Home Assistant.
+
+Home Assistant's REST `/api/states` endpoint does not include area data;
+area information lives in HA's area registry which is only directly
+exposed over WebSocket. To stay REST-only and keep the existing httpx
+client + long-lived token contract, this module uses HA's `/api/template`
+endpoint to render a single Jinja that emits `entity_id<US>area_name`
+for every entity. Server-side, `area_name(entity_id)` walks the
+entity → device → area chain automatically (matches HA's own behavior).
+
+The mapping is cached in memory with a short TTL (the area registry
+rarely changes; users tolerate a few minutes of staleness).
+"""
+
+import asyncio
+import logging
+import time
+from typing import Dict, Optional
+
+import httpx
+
+from app.config import HA_URL, get_ha_headers
+
+logger = logging.getLogger(__name__)
+
+# Default cache duration. Area registry changes very rarely (a user
+# adding/renaming a room), so this can be aggressive.
+_DEFAULT_TTL_SECONDS = 300
+
+# ASCII unit separator — used to delimit entity_id from area name in the
+# template output. Won't appear in entity IDs (they're [a-z0-9_.] only) or
+# in any sensible area name.
+_US = "\x1f"
+
+# Single Jinja that emits one line per entity. We embed the entity loop
+# in the template so HA does the work server-side; one REST call returns
+# the entire entity→area map regardless of how many entities are defined.
+_AREA_TEMPLATE = (
+    "{%- set ns = namespace(items=[]) -%}\n"
+    "{%- for s in states -%}\n"
+    "  {%- set a = area_name(s.entity_id) -%}\n"
+    f"  {{%- set ns.items = ns.items + [(s.entity_id ~ '{_US}' ~ (a or ''))] -%}}\n"
+    "{%- endfor -%}\n"
+    "{{ ns.items | join('\\n') }}\n"
+)
+
+
+class AreaCache:
+    """In-memory TTL cache of {entity_id: area_name | None}.
+
+    Single-flight: concurrent get/all calls during a refresh share one
+    HTTP request rather than stampeding the HA API.
+    """
+
+    def __init__(self, ttl_seconds: int = _DEFAULT_TTL_SECONDS):
+        self._cache: Dict[str, Optional[str]] = {}
+        self._expires_at: float = 0.0
+        self._ttl = ttl_seconds
+        self._lock = asyncio.Lock()
+
+    async def get_all(self, client: httpx.AsyncClient) -> Dict[str, Optional[str]]:
+        """Return the full entity→area map, refreshing if expired."""
+        if time.monotonic() < self._expires_at:
+            return self._cache
+        async with self._lock:
+            # Double-check inside the lock — another coroutine may have
+            # refreshed while we were waiting.
+            if time.monotonic() < self._expires_at:
+                return self._cache
+            await self._refresh(client)
+        return self._cache
+
+    async def get(self, client: httpx.AsyncClient, entity_id: str) -> Optional[str]:
+        """Return the area name for one entity, or None if no area assigned."""
+        all_areas = await self.get_all(client)
+        return all_areas.get(entity_id)
+
+    def invalidate(self) -> None:
+        """Discard the cache. Next get/get_all refreshes from HA. If that
+        refresh fails, callers see None rather than stale data."""
+        self._cache = {}
+        self._expires_at = 0.0
+
+    async def _refresh(self, client: httpx.AsyncClient) -> None:
+        """Re-fetch the area map via /api/template."""
+        try:
+            response = await client.post(
+                f"{HA_URL}/api/template",
+                headers=get_ha_headers(),
+                json={"template": _AREA_TEMPLATE},
+                timeout=30,
+            )
+            response.raise_for_status()
+        except Exception as e:
+            # Don't crash callers; serve stale cache and back off retry for
+            # a minute to avoid hammering a flaky HA.
+            logger.warning("area cache refresh failed: %s", e)
+            self._expires_at = time.monotonic() + 60
+            return
+
+        cache: Dict[str, Optional[str]] = {}
+        for line in response.text.splitlines():
+            # Defensive: skip blank lines and entries the template produced
+            # without our separator.
+            if _US not in line:
+                continue
+            entity_id, area = line.split(_US, 1)
+            entity_id = entity_id.strip()
+            if not entity_id:
+                continue
+            cache[entity_id] = area.strip() or None
+
+        self._cache = cache
+        self._expires_at = time.monotonic() + self._ttl
+        logger.debug("area cache refreshed: %d entities, %d with areas",
+                     len(cache), sum(1 for a in cache.values() if a))
+
+
+# Module-level singleton. Tests can reset via .invalidate() / monkeypatch.
+_cache = AreaCache()
+
+
+async def get_area(client: httpx.AsyncClient, entity_id: str) -> Optional[str]:
+    return await _cache.get(client, entity_id)
+
+
+async def get_all_areas(client: httpx.AsyncClient) -> Dict[str, Optional[str]]:
+    return await _cache.get_all(client)
+
+
+def invalidate_cache() -> None:
+    _cache.invalidate()

--- a/app/hass.py
+++ b/app/hass.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 from datetime import datetime, timedelta, timezone
 
+from app.areas import get_area, get_all_areas
 from app.config import HA_URL, HA_TOKEN, get_ha_headers
 
 # Set up logging
@@ -19,7 +20,7 @@ _client: Optional[httpx.AsyncClient] = None
 
 # Default field sets for different verbosity levels
 # Lean fields for standard requests (optimized for token efficiency)
-DEFAULT_LEAN_FIELDS = ["entity_id", "state", "attr.friendly_name"]
+DEFAULT_LEAN_FIELDS = ["entity_id", "state", "area", "attr.friendly_name"]
 
 # Common fields that are typically needed for entity operations
 DEFAULT_STANDARD_FIELDS = ["entity_id", "state", "attributes", "last_updated"]
@@ -140,6 +141,10 @@ def filter_fields(data: Dict[str, Any], fields: List[str]) -> Dict[str, Any]:
     for field in fields:
         if field == "state":
             result["state"] = data.get("state")
+        elif field == "area":
+            # Area is injected by hass-mcp from the HA area registry; absent
+            # in the raw /api/states payload but added before filtering.
+            result["area"] = data.get("area")
         elif field == "attributes":
             result["attributes"] = data.get("attributes", {})
         elif field.startswith("attr.") and len(field) > 5:
@@ -189,12 +194,16 @@ async def get_entity_state(
     # Fetch directly
     client = await get_client()
     response = await client.get(
-        f"{HA_URL}/api/states/{entity_id}", 
+        f"{HA_URL}/api/states/{entity_id}",
         headers=get_ha_headers()
     )
     response.raise_for_status()
     entity_data = response.json()
-    
+
+    # Enrich with area data from the HA area registry (HA's REST states
+    # endpoint omits this; we resolve it via /api/template — see app/areas.py).
+    entity_data["area"] = await get_area(client, entity_id)
+
     # Apply field filtering if requested
     if fields:
         # User-specified fields take precedence
@@ -241,7 +250,13 @@ async def get_entities(
     response = await client.get(f"{HA_URL}/api/states", headers=get_ha_headers())
     response.raise_for_status()
     entities = response.json()
-    
+
+    # Enrich each entity with area data. One bulk template call covers
+    # the whole list regardless of size.
+    areas = await get_all_areas(client)
+    for entity in entities:
+        entity["area"] = areas.get(entity["entity_id"])
+
     # Filter by domain if specified
     if domain:
         entities = [entity for entity in entities if entity["entity_id"].startswith(f"{domain}.")]
@@ -578,20 +593,24 @@ async def get_system_overview() -> Dict[str, Any]:
         response = await client.get(f"{HA_URL}/api/states", headers=get_ha_headers())
         response.raise_for_status()
         all_entities_raw = response.json()
-        
+
+        # Resolve areas in one bulk template call.
+        areas = await get_all_areas(client)
+
         # Apply lean formatting to reduce token usage in the response
         all_entities = []
         for entity in all_entities_raw:
+            entity["area"] = areas.get(entity["entity_id"])
             domain = entity["entity_id"].split(".")[0]
-            
+
             # Start with basic lean fields
-            lean_fields = ["entity_id", "state", "attr.friendly_name"]
-            
+            lean_fields = ["entity_id", "state", "area", "attr.friendly_name"]
+
             # Add domain-specific important attributes
             if domain in DOMAIN_IMPORTANT_ATTRIBUTES:
                 for attr in DOMAIN_IMPORTANT_ATTRIBUTES[domain]:
                     lean_fields.append(f"attr.{attr}")
-            
+
             # Filter and add to result
             all_entities.append(filter_fields(entity, lean_fields))
         
@@ -655,17 +674,19 @@ async def get_system_overview() -> Dict[str, Any]:
             common_attributes = sorted(attribute_counts.items(), key=lambda x: x[1], reverse=True)[:5]
             overview["domain_attributes"][domain] = [attr for attr, count in common_attributes]
             
-            # Group by area if available
+            # Group by area. Entities without an area land under "Unassigned"
+            # rather than the misleading "Unknown" the previous implementation
+            # produced (it was reading area from attributes, which HA does
+            # not populate — see Issue #28).
             for entity in entities:
-                area_id = entity.get("attributes", {}).get("area_id", "Unknown")
-                area_name = entity.get("attributes", {}).get("area_name", area_id)
-                
+                area_name = entity.get("area") or "Unassigned"
+
                 if area_name not in overview["area_distribution"]:
                     overview["area_distribution"][area_name] = {}
-                
+
                 if domain not in overview["area_distribution"][area_name]:
                     overview["area_distribution"][area_name][domain] = 0
-                    
+
                 overview["area_distribution"][area_name][domain] += 1
         
         # Add summary information

--- a/app/server.py
+++ b/app/server.py
@@ -374,6 +374,52 @@ async def get_all_entities_resource() -> str:
     return result
 
 @mcp.tool()
+@async_handler("get_entities_by_area")
+async def get_entities_by_area(
+    area: str,
+    domain: Optional[str] = None,
+    lean: bool = True,
+) -> Dict[str, Any]:
+    """
+    Get all entities assigned to a specific Home Assistant area (room).
+
+    Area lookup is case-insensitive and matches the area's name as configured
+    in Home Assistant (e.g., "Kitchen", "Living Room"). Entities inherit their
+    area from their parent device when no area is set directly, matching HA's
+    own resolution behavior.
+
+    Args:
+        area: Name of the area to filter by (case-insensitive)
+        domain: Optional domain to further filter results (e.g., 'light')
+        lean: If True (default), returns token-efficient entity records
+
+    Returns:
+        A dictionary containing:
+        - area: The matched area name (as canonicalized by HA)
+        - count: Number of matching entities
+        - entities: List of entity records with their state and area
+
+    Examples:
+        get_entities_by_area(area="Kitchen") - everything in the kitchen
+        get_entities_by_area(area="Living Room", domain="light") - lights only
+    """
+    logger.info(f"Listing entities in area: {area} (domain={domain})")
+    entities = await get_entities(domain=domain, limit=10_000, lean=lean)
+
+    needle = area.strip().lower()
+    matches = [
+        e for e in entities
+        if (e.get("area") or "").lower() == needle
+    ]
+    canonical_area = matches[0]["area"] if matches else area
+    return {
+        "area": canonical_area,
+        "count": len(matches),
+        "entities": matches,
+    }
+
+
+@mcp.tool()
 @async_handler("search_entities_tool")
 async def search_entities_tool(query: str, limit: int = 20) -> Dict[str, Any]:
     """

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -129,7 +129,7 @@ async def test_docker_stdio_transport(docker_image):
             init = await session.initialize()
             assert init.serverInfo.name == "Hass-MCP"
             tools = await session.list_tools()
-            assert len(tools.tools) == 12
+            assert len(tools.tools) == 13
             prompts = await session.list_prompts()
             assert len(prompts.prompts) == 7
 
@@ -163,7 +163,7 @@ async def test_docker_streamable_http_transport(docker_image):
                 init = await session.initialize()
                 assert init.serverInfo.name == "Hass-MCP"
                 tools = await session.list_tools()
-                assert len(tools.tools) == 12
+                assert len(tools.tools) == 13
 
                 result = await session.call_tool("get_version", {})
                 assert not result.isError

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -37,6 +37,16 @@ def mock_get_client():
     yield
 
 
+@pytest.fixture(autouse=True)
+def reset_area_cache():
+    """Area cache is a module-level singleton; force a fresh fetch each test
+    so respx mocks of /api/template are honored."""
+    from app.areas import invalidate_cache
+    invalidate_cache()
+    yield
+    invalidate_cache()
+
+
 # --- Sanity tests (expected to pass on master) ------------------------------
 
 async def test_initialize_handshake():
@@ -52,6 +62,7 @@ EXPECTED_TOOLS = {
     "call_service_tool",
     "domain_summary_tool",
     "entity_action",
+    "get_entities_by_area",
     "get_entity",
     "get_error_log",
     "get_history",
@@ -170,6 +181,9 @@ async def test_get_entity_via_protocol():
             },
         )
     )
+    respx.post("http://localhost:8123/api/template").mock(
+        return_value=httpx.Response(200, text="light.kitchen\x1fKitchen")
+    )
     async with create_connected_server_and_client_session(
         mcp._mcp_server, raise_exceptions=True
     ) as client:
@@ -177,7 +191,133 @@ async def test_get_entity_via_protocol():
             "get_entity", arguments={"entity_id": "light.kitchen"}
         )
         assert not result.isError
-        assert "on" in result.content[0].text
+        text = result.content[0].text
+        assert "on" in text
+        assert "Kitchen" in text, "area should be surfaced in the lean response"
+
+
+# --- area resolution -------------------------------------------------------
+
+@respx.mock
+async def test_get_entity_includes_area_from_template():
+    """Single-entity area lookup hits /api/template; area surfaces in output."""
+    respx.get("http://localhost:8123/api/states/light.living_room").mock(
+        return_value=httpx.Response(200, json={
+            "entity_id": "light.living_room",
+            "state": "on",
+            "attributes": {"friendly_name": "Living Room Lamp"},
+            "last_changed": "2026-01-01T00:00:00+00:00",
+            "last_updated": "2026-01-01T00:00:00+00:00",
+        })
+    )
+    respx.post("http://localhost:8123/api/template").mock(
+        return_value=httpx.Response(
+            200, text="light.living_room\x1fLiving Room\nlight.kitchen\x1fKitchen"
+        )
+    )
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_entity", arguments={"entity_id": "light.living_room"}
+        )
+        assert not result.isError
+        assert "Living Room" in result.content[0].text
+
+
+@respx.mock
+async def test_entity_without_area_returns_null_not_unknown():
+    """Entities with no area assigned must surface as None, not 'Unknown' —
+    Issue #28 was caused by the previous 'Unknown' fallback misleading the LLM."""
+    import json
+
+    respx.get("http://localhost:8123/api/states/sensor.backup_state").mock(
+        return_value=httpx.Response(200, json={
+            "entity_id": "sensor.backup_state",
+            "state": "idle",
+            "attributes": {},
+            "last_changed": "2026-01-01T00:00:00+00:00",
+            "last_updated": "2026-01-01T00:00:00+00:00",
+        })
+    )
+    # Template returns the entity with empty area (the canonical "no area" shape).
+    respx.post("http://localhost:8123/api/template").mock(
+        return_value=httpx.Response(200, text="sensor.backup_state\x1f")
+    )
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_entity",
+            arguments={"entity_id": "sensor.backup_state", "detailed": True},
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["area"] is None, f"area should be null, got {payload['area']!r}"
+
+
+@respx.mock
+async def test_get_entities_by_area_filters_correctly():
+    """get_entities_by_area must return only entities in the named area,
+    case-insensitively, and pass through additional domain filtering."""
+    import json
+
+    respx.get("http://localhost:8123/api/states").mock(
+        return_value=httpx.Response(200, json=[
+            {"entity_id": "light.kitchen", "state": "on", "attributes": {}},
+            {"entity_id": "light.bedroom", "state": "off", "attributes": {}},
+            {"entity_id": "sensor.kitchen_temp", "state": "20", "attributes": {}},
+        ])
+    )
+    respx.post("http://localhost:8123/api/template").mock(
+        return_value=httpx.Response(200, text=(
+            "light.kitchen\x1fKitchen\n"
+            "light.bedroom\x1fBedroom\n"
+            "sensor.kitchen_temp\x1fKitchen"
+        ))
+    )
+
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        # Case-insensitive area match, no domain filter.
+        result = await client.call_tool("get_entities_by_area", {"area": "kitchen"})
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["count"] == 2
+        ids = {e["entity_id"] for e in payload["entities"]}
+        assert ids == {"light.kitchen", "sensor.kitchen_temp"}
+        assert payload["area"] == "Kitchen"  # canonicalized from the matched entities
+
+
+@respx.mock
+async def test_area_cache_handles_template_failure_gracefully():
+    """If /api/template fails, area lookups return None but the tool still
+    succeeds — area is a best-effort enrichment, not a hard requirement."""
+    import json
+
+    respx.get("http://localhost:8123/api/states/light.kitchen").mock(
+        return_value=httpx.Response(200, json={
+            "entity_id": "light.kitchen",
+            "state": "on",
+            "attributes": {},
+            "last_changed": "2026-01-01T00:00:00+00:00",
+            "last_updated": "2026-01-01T00:00:00+00:00",
+        })
+    )
+    respx.post("http://localhost:8123/api/template").mock(
+        return_value=httpx.Response(500, text="Internal Server Error")
+    )
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_entity",
+            arguments={"entity_id": "light.kitchen", "detailed": True},
+        )
+        assert not result.isError, "tool must not fail when area enrichment fails"
+        payload = json.loads(result.content[0].text)
+        assert payload["area"] is None
 
 
 @respx.mock

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -50,6 +50,7 @@ EXPECTED_TOOLS = {
     "call_service_tool",
     "domain_summary_tool",
     "entity_action",
+    "get_entities_by_area",
     "get_entity",
     "get_error_log",
     "get_history",


### PR DESCRIPTION
## Summary

Fixes #28. Adds per-entity `area` to every tool that returns entity data, plus a new `get_entities_by_area` tool.

Previously `system_overview` reported every entity under a fake `"Unknown"` area because the code read `attributes.area_id` from `/api/states` — but **HA never populates that field**. On a real 1287-entity test instance, 100% of entities were misbucketed.

## Why this approach

Researched against HA's docs, the [`mcp_server` integration source](https://github.com/home-assistant/core/tree/dev/homeassistant/components/mcp_server), and three other options:

- **REST area-registry endpoint**: doesn't exist (4-year feature request, never shipped).
- **WebSocket `config/area_registry/list`**: works but adds a new dep, new auth path, new failure mode. Overkill for one feature.
- **`POST /api/template` with `area_name(entity_id)`** ← winner. One REST call, reuses our existing `httpx` client and LLAT, server-side does the entity→device fallback for free. Exactly mirrors HA's own `_get_exposed_entities` in `homeassistant/helpers/llm.py`.

Cached in-memory with a 5-minute TTL (area registry rarely changes).

## Live validation

Tested against a real 1287-entity HA instance:

```
Before (Issue #28):              After:
  Unknown:  1287                   Master Bedroom: 174
                                   Living Room:    170
                                   Kitchen:        125
                                   Server Closet:  102
                                   Service Area:    97
                                   Massage Room:    65
                                   Guest Room:      47
                                   Guest Suite:     31
                                   Print Room:       1
                                   Unassigned:     475  ← entities with no
                                                          physical location
                                                          (backup sensors,
                                                          conversation/system)
```

Template refresh: **20 ms for 1287 entities**. The 5-minute TTL is generous; even with no cache, this is a single fast call.

`get_entities_by_area("Kitchen", domain="light")` correctly returned three real kitchen lights with live states.

## Changes

- **`app/areas.py`** (new) — `AreaCache` class. Bulk-fetch via `/api/template`, single-flight via `asyncio.Lock`, 5-min TTL, graceful degradation on HA failure (cache stays empty, area returns `None`, callers don't crash).
- **`app/hass.py`** — inject `area` into `get_entity_state`, `get_entities`, and `get_system_overview`. Add `"area"` to `DEFAULT_LEAN_FIELDS` and to `filter_fields`'s whitelist so it survives lean filtering. Replace the broken `attributes.area_id` reads.
- **`app/server.py`** — new `get_entities_by_area` tool.
- **`tests/test_protocol.py`** — four new tests: `get_entity` surfaces area, no-area entities return `null` (not `"Unknown"`), `get_entities_by_area` filters case-insensitively + canonicalizes the area name, graceful degradation when `/api/template` fails.
- **`tests/{test_protocol,test_transports,test_docker}.py`** — expected tool count/set bumped from 12 to 13.
- **`README.md` / `CHANGELOG.md`** — usage examples + `[Unreleased]` entry.

## Tests

```
$ uv run pytest tests/
= 44 passed in 8.58s =
```

Includes 4 new area-specific tests, all transport tests, and the Docker integration tests (which now rebuild against the new tool surface — `tools=13`, stdio + HTTP both verified through the rebuilt image).

## Anti-patterns avoided (per the research)

- ❌ Don't add a WebSocket dep for one feature
- ❌ Don't `area_id(entity_id)` — HA docs explicitly say it doesn't walk to device fallback. Use `area_name(entity_id)` which does
- ❌ Don't default missing areas to `"Unknown"` — return `null` (or bucket as `"Unassigned"` in summary view). The whole bug was the fake "Unknown" bucket
- ❌ Don't call `/api/template` per entity. One bulk render covers everything