### PR TITLE
feat(tls): support custom CA via OS trust store + SSL_CERT_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom CA support for users running their own PKI (step-ca, smallstep,
+  homelab OpenSSL). hass-mcp now verifies HTTPS against the OS-native
+  trust store (macOS Keychain / Windows Cert Store / Linux
+  ca-certificates) via [truststore](https://truststore.readthedocs.io/),
+  and honors `SSL_CERT_FILE` for explicit overrides (the canonical
+  Docker pattern: bind-mount the CA file, set the env var). Supersedes
+  [#15] with a portable, defaults-safe mechanism — no `verify=False`
+  fallback, no requests-specific `REQUESTS_CA_BUNDLE` shim.
+
 ## [0.4.0] - 2026-05-17
 
 ### Added
@@ -113,6 +123,7 @@ Initial PyPI release.
 [0.1.1]: https://github.com/voska/hass-mcp/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/voska/hass-mcp/releases/tag/v0.1.0
 
+[#15]: https://github.com/voska/hass-mcp/pull/15
 [#19]: https://github.com/voska/hass-mcp/issues/19
 [#23]: https://github.com/voska/hass-mcp/issues/23
 [#28]: https://github.com/voska/hass-mcp/issues/28

--- a/README.md
+++ b/README.md
@@ -200,6 +200,24 @@ The MCP endpoint is at `/mcp`. Point your client at `http://<host>:<port>/mcp`.
 
 The server honors the `PORT` environment variable (Smithery's convention) in addition to `MCP_PORT`. Smithery deployment requires `--http` mode and reads `PORT` automatically.
 
+## Custom / private CA
+
+If your Home Assistant instance serves a certificate signed by your own CA (step-ca, smallstep, homelab OpenSSL), hass-mcp can verify it without disabling TLS:
+
+- **Locally**: install the CA root in your OS trust store (macOS Keychain, Windows Cert Store, or `update-ca-certificates` on Linux). hass-mcp picks it up automatically via [truststore](https://truststore.readthedocs.io/).
+- **In Docker** (or any sandboxed runtime): bind-mount the CA file and point `SSL_CERT_FILE` at it.
+
+```bash
+docker run --rm \
+  -v /path/to/your-ca.crt:/etc/ssl/certs/your-ca.crt:ro \
+  -e SSL_CERT_FILE=/etc/ssl/certs/your-ca.crt \
+  -e HA_URL=https://homeassistant.example.internal:8123 \
+  -e HA_TOKEN=YOUR_LONG_LIVED_TOKEN \
+  voska/hass-mcp:latest
+```
+
+`SSL_CERT_FILE` always takes precedence over the OS store when set. `verify=False` is intentionally not supported — use `HA_URL=http://...` if you genuinely want unencrypted local LAN traffic.
+
 ## Usage Examples
 
 Here are some examples of prompts you can use with Claude once Hass-MCP is set up:

--- a/app/hass.py
+++ b/app/hass.py
@@ -3,7 +3,11 @@ from typing import Dict, Any, Optional, List, TypeVar, Callable, Awaitable, Unio
 import functools
 import inspect
 import logging
+import os
+import ssl
 from datetime import datetime, timedelta, timezone
+
+import truststore
 
 from app.areas import get_area, get_all_areas
 from app.config import HA_URL, HA_TOKEN, get_ha_headers
@@ -87,13 +91,38 @@ def handle_api_errors(func: F) -> F:
     
     return cast(F, wrapper)
 
+def _build_ssl_context() -> ssl.SSLContext:
+    """Build the TLS verification context.
+
+    Layered so users running an in-house CA (e.g. step-ca, smallstep) can
+    connect to a properly-signed HA instance on any platform / deployment
+    mode without weakening verification:
+
+    1. If `SSL_CERT_FILE` is set, use it. This is the OpenSSL standard env
+       var, honored by every modern tool. It's the primary mechanism for
+       Docker (bind-mount the CA, set the env var) and explicit overrides.
+    2. Otherwise use truststore, which bridges to the OS-native trust store
+       (macOS Keychain, Windows Cert Store, Linux ca-certificates). Users
+       who installed their CA at the OS level get it for free.
+
+    No REQUESTS_CA_BUNDLE shim — that's a requests-ism, not a standard.
+    No verify=False fallback — silent downgrade is worse than a hard failure.
+    """
+    cert_file = os.environ.get("SSL_CERT_FILE")
+    if cert_file:
+        logger.debug("TLS: using SSL_CERT_FILE=%s", cert_file)
+        return ssl.create_default_context(cafile=cert_file)
+    logger.debug("TLS: using OS native trust store via truststore")
+    return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+
 # Persistent HTTP client
 async def get_client() -> httpx.AsyncClient:
     """Get a persistent httpx client for Home Assistant API calls"""
     global _client
     if _client is None:
         logger.debug("Creating new HTTP client")
-        _client = httpx.AsyncClient(timeout=10.0)
+        _client = httpx.AsyncClient(timeout=10.0, verify=_build_ssl_context())
     return _client
 
 async def cleanup_client() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.13"
 dependencies = [
     "mcp[cli]>=1.27,<2",
     "httpx>=0.27.0",
+    "truststore>=0.10",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_hass.py
+++ b/tests/test_hass.py
@@ -235,3 +235,52 @@ class TestHassAPI:
         # Verify that both functions have a docstring
         assert test_dict_function.__doc__ == "Test function that returns a dict."
         assert test_str_function.__doc__ == "Test function that returns a string."
+
+
+class TestSSLContext:
+    """The TLS verification layer must support both OS-native trust stores
+    (laptop users who installed their CA at the OS level) and explicit
+    cert-file overrides (the canonical Docker pattern)."""
+
+    def test_default_uses_truststore_os_native_store(self, monkeypatch):
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        import truststore
+        from app.hass import _build_ssl_context
+
+        ctx = _build_ssl_context()
+        assert isinstance(ctx, truststore.SSLContext)
+
+    def test_ssl_cert_file_takes_precedence(self, monkeypatch, tmp_path):
+        # Build a minimal valid PEM certificate so create_default_context
+        # can actually load it. (Self-signed dummy, not used for trust.)
+        import datetime
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.x509.oid import NameOID
+
+        key = ec.generate_private_key(ec.SECP256R1())
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=1))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .sign(key, hashes.SHA256())
+        )
+        pem_path = tmp_path / "test-ca.crt"
+        pem_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+        monkeypatch.setenv("SSL_CERT_FILE", str(pem_path))
+
+        import ssl
+        import truststore
+        from app.hass import _build_ssl_context
+
+        ctx = _build_ssl_context()
+        # Standard SSLContext loaded from the file, not truststore.
+        assert isinstance(ctx, ssl.SSLContext)
+        assert not isinstance(ctx, truststore.SSLContext)

--- a/uv.lock
+++ b/uv.lock
@@ -185,6 +185,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
+    { name = "truststore" },
 ]
 
 [package.optional-dependencies]
@@ -201,6 +202,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
     { name = "respx", marker = "extra == 'test'", specifier = ">=0.21.1" },
+    { name = "truststore", specifier = ">=0.10" },
 ]
 provides-extras = ["test"]
 
@@ -675,6 +677,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102, upload-time = "2025-03-08T10:55:34.504Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995, upload-time = "2025-03-08T10:55:32.662Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Users running their own PKI (step-ca, smallstep, homelab OpenSSL) need hass-mcp to verify their HA's certificate without disabling TLS. Supersedes #15 with a portable, defaults-safe mechanism that works across local installs, Docker containers, and standalone deployments.

## Two layered mechanisms

1. **OS native trust store via [`truststore`](https://truststore.readthedocs.io/)** — the same library pip has used by default since 24.2 (mid-2024). Bridges to macOS Keychain, Windows Cert Store, and Linux ca-certificates. Users who installed their CA at the OS level get it for free with no config.

2. **`SSL_CERT_FILE` explicit override** — the canonical OpenSSL env var, honored by every TLS-aware tool. Primary mechanism for Docker (bind-mount + env var). Also the override path on any platform.

```python
# app/hass.py
def _build_ssl_context() -> ssl.SSLContext:
    cert_file = os.environ.get("SSL_CERT_FILE")
    if cert_file:
        return ssl.create_default_context(cafile=cert_file)
    return truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)

_client = httpx.AsyncClient(timeout=10.0, verify=_build_ssl_context())
```

## Deployment coverage

| Mode | How it works |
|---|---|
| Laptop (any OS) with CA installed at OS level | truststore picks it up automatically |
| Docker | bind-mount the CA, set `SSL_CERT_FILE` — explicit override path |
| Standalone server / Smithery | same as Docker: env var + mounted file |
| Anyone with `SSL_CERT_FILE` already set | honored on every platform |

Documented in README with the canonical Docker example.

## Explicitly declined

- **`REQUESTS_CA_BUNDLE`** — `requests`-specific alias, not a standard. We're not a `requests` codebase; don't propagate it.
- **`verify=False`** — silent downgrade is worse than a hard failure. Users who genuinely want unencrypted local LAN can use `HA_URL=http://...` which is already documented.

## Why this is better than #15

#15 reads `REQUESTS_CA_BUNDLE`/`SSL_CERT_FILE` and passes to `verify=`. Two problems:

1. `SSL_CERT_FILE` is already honored by httpx natively when `trust_env=True` (default). The env-var read is partially redundant.
2. **Doesn't help macOS users with CAs in Keychain** — OpenSSL doesn't read the Keychain. And doesn't help Linux users who installed via `update-ca-certificates` if hass-mcp runs in a Docker container without that file mounted in.

This PR fixes both: truststore handles every OS-native store, `SSL_CERT_FILE` handles every explicit-path scenario.

## Dependency

Adds `truststore>=0.10`. ~30 KB, no transitive runtime deps. Used by pip, uv, and recommended in the [httpx SSL docs](https://www.python-httpx.org/advanced/ssl/) for OS-store integration. Python 3.13 (our minimum) satisfies its 3.10+ floor.

## Tests

```
$ uv run pytest tests/
= 46 passed in 9.11s =
```

Two new tests in `tests/test_hass.py::TestSSLContext`:
- `test_default_uses_truststore_os_native_store` — confirms truststore is selected when no env var
- `test_ssl_cert_file_takes_precedence` — generates a self-signed PEM, points `SSL_CERT_FILE` at it, confirms a stdlib `ssl.SSLContext` is built from the file (not truststore)

## Credit

@rmoriz flagged the right problem in #15. The cleaner mechanism preserves the spirit (don't weaken TLS) with a more portable implementation. Their PR can be closed as superseded; `Co-Authored-By` on the merge commit.