### PR TITLE
docs(changelog): 0.4.1 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-17
+
 ### Added
 - Custom CA support for users running their own PKI (step-ca, smallstep,
   homelab OpenSSL). hass-mcp now verifies HTTPS against the OS-native
@@ -114,7 +116,8 @@ functional changes.
 
 Initial PyPI release.
 
-[Unreleased]: https://github.com/voska/hass-mcp/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/voska/hass-mcp/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/voska/hass-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/voska/hass-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/voska/hass-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/voska/hass-mcp/compare/v0.1.3...v0.2.0


### PR DESCRIPTION
Lift custom-CA entry to [0.4.1]. Tag follows.