### PR TITLE
feat(error-log): server-side filters (level, integration, search, lines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `get_error_log` accepts optional filter parameters: `level`,
+  `integration`, `search_term`, and `lines`. Filters combine with AND
+  semantics and are applied server-side after ANSI stripping; the
+  returned `error_count`, `warning_count`, `integration_mentions`, and
+  `total_lines` are computed over the filtered output so they always
+  match what's returned. A new `filters_applied` field surfaces which
+  filters were active. Supersedes [#34] — ported fresh against current
+  master with thanks to @cstosgale for the original implementation.
+
 ## [0.4.1] - 2026-05-17
 
 ### Added
@@ -132,4 +142,5 @@ Initial PyPI release.
 [#28]: https://github.com/voska/hass-mcp/issues/28
 [#29]: https://github.com/voska/hass-mcp/issues/29
 [#33]: https://github.com/voska/hass-mcp/pull/33
+[#34]: https://github.com/voska/hass-mcp/pull/34
 [#35]: https://github.com/voska/hass-mcp/issues/35

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Here are some examples of prompts you can use with Claude once Hass-MCP is set u
 - "Create an automation that turns on the lights at sunset"
 - "Help me troubleshoot why my bedroom motion sensor automation isn't working"
 - "Search for entities related to my living room"
+- "Show me the last 50 ERROR lines from the Home Assistant log"
+- "What's been failing on the mqtt integration today?"
 
 ## Available Tools
 
@@ -246,7 +248,9 @@ Hass-MCP provides several tools for interacting with Home Assistant:
 - `call_service_tool`: Call any Home Assistant service
 - `restart_ha`: Restart Home Assistant
 - `get_history`: Get the state history of an entity
-- `get_error_log`: Get the Home Assistant error log
+- `get_error_log`: Get the Home Assistant error log, with optional
+  `level` / `integration` / `search_term` / `lines` filters applied
+  server-side so noisy logs don't blow Claude's context
 - `get_entities_by_area`: List entities in a specific area / room
 
 ## Prompts for Guided Conversations

--- a/app/hass.py
+++ b/app/hass.py
@@ -487,43 +487,93 @@ async def restart_home_assistant() -> Dict[str, Any]:
     return await call_service("homeassistant", "restart", {})
 
 @handle_api_errors
-async def get_hass_error_log() -> Dict[str, Any]:
+async def get_hass_error_log(
+    level: Optional[str] = None,
+    integration: Optional[str] = None,
+    search_term: Optional[str] = None,
+    lines: Optional[int] = None,
+) -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting.
+
+    All filters are optional and combine (AND semantics). Filtering happens
+    client-side after the full log is fetched from HA; stats (counts,
+    integration mentions, total_lines) are computed over the filtered text
+    so they match what's returned.
+
+    Args:
+        level: Filter to lines containing this log level (ERROR, WARNING,
+               INFO, DEBUG). Case-insensitive.
+        integration: Filter to lines mentioning this integration. Matches
+                     `[name]` or `[homeassistant.components.name]`.
+                     Case-insensitive.
+        search_term: Case-insensitive substring filter applied to each line.
+        lines: Return only the most recent N lines (after other filters).
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
-        - error_count: Number of ERROR entries found
-        - warning_count: Number of WARNING entries found
-        - integration_mentions: Map of integration names to mention counts
-        - error: Error message if retrieval failed
+        - log_text: The filtered log text (ANSI codes stripped)
+        - error_count: ERROR entries in the filtered text
+        - warning_count: WARNING entries in the filtered text
+        - integration_mentions: Map of integration names to counts
+        - total_lines: Total lines returned
+        - filters_applied: Echo of which filters were active
+        - error: Set only on retrieval failure
     """
     import re
 
     ansi_pattern = re.compile(r'\x1b\[[0-9;]*m')
 
+    def apply_filters(text: str) -> str:
+        log_lines = text.splitlines()
+        if level:
+            needle = level.upper()
+            log_lines = [ln for ln in log_lines if needle in ln]
+        if integration:
+            needle = integration.lower()
+            bare = f"[{needle}]"
+            namespaced = f"[homeassistant.components.{needle}]"
+            log_lines = [ln for ln in log_lines if bare in ln.lower() or namespaced in ln.lower()]
+        if search_term:
+            needle = search_term.lower()
+            log_lines = [ln for ln in log_lines if needle in ln.lower()]
+        if lines is not None and lines > 0:
+            log_lines = log_lines[-lines:]
+        return "\n".join(log_lines)
+
     def parse_log_text(log_text: str) -> Dict[str, Any]:
         # HA OS logs include ANSI color codes that distort ERROR/WARNING counts
         # and contaminate the returned text.
         clean_text = ansi_pattern.sub('', log_text)
+        # Filtering happens after ANSI stripping so substring matches aren't
+        # disrupted by escape sequences.
+        filtered = apply_filters(clean_text)
 
-        error_count = clean_text.count("ERROR")
-        warning_count = clean_text.count("WARNING")
+        error_count = filtered.count("ERROR")
+        warning_count = filtered.count("WARNING")
 
         integration_mentions: Dict[str, int] = {}
-        for match in re.finditer(r'\[([a-zA-Z0-9_\.]+)\]', clean_text):
-            integration = match.group(1).lower()
+        for match in re.finditer(r'\[([a-zA-Z0-9_\.]+)\]', filtered):
+            name = match.group(1).lower()
             # Collapse homeassistant.components.X to X
-            if integration.startswith('homeassistant.components.'):
-                integration = integration.split('.')[-1]
-            integration_mentions[integration] = integration_mentions.get(integration, 0) + 1
+            if name.startswith('homeassistant.components.'):
+                name = name.split('.')[-1]
+            integration_mentions[name] = integration_mentions.get(name, 0) + 1
+
+        filters_applied = {
+            k: v for k, v in {
+                "level": level, "integration": integration,
+                "search_term": search_term, "lines": lines,
+            }.items() if v is not None
+        }
 
         return {
-            "log_text": clean_text,
+            "log_text": filtered,
             "error_count": error_count,
             "warning_count": warning_count,
             "integration_mentions": integration_mentions,
+            "total_lines": len(filtered.splitlines()) if filtered else 0,
+            "filters_applied": filters_applied,
         }
 
     try:

--- a/app/server.py
+++ b/app/server.py
@@ -1273,25 +1273,62 @@ async def get_history(entity_id: str, hours: int = 24) -> Dict[str, Any]:
 
 @mcp.tool()
 @async_handler("get_error_log")
-async def get_error_log() -> Dict[str, Any]:
+async def get_error_log(
+    level: Optional[str] = None,
+    integration: Optional[str] = None,
+    search_term: Optional[str] = None,
+    lines: Optional[int] = None,
+) -> Dict[str, Any]:
     """
-    Get the Home Assistant error log for troubleshooting
-    
+    Get the Home Assistant error log for troubleshooting.
+
+    All filters are optional and combine (AND semantics). Stats
+    (error_count, warning_count, integration_mentions, total_lines) are
+    computed over the filtered output so they match what's returned.
+
+    Args:
+        level: Filter to lines containing this log level — ERROR, WARNING,
+               INFO, or DEBUG. Case-insensitive.
+        integration: Filter to lines mentioning this integration. Matches
+                     `[name]` or `[homeassistant.components.name]`.
+                     Case-insensitive.
+        search_term: Case-insensitive substring filter applied per line.
+                     Useful for entity IDs, exception names, etc.
+        lines: Return only the most recent N lines (applied after other
+               filters). Useful when you only care about the tail.
+
     Returns:
         A dictionary containing:
-        - log_text: The full error log text
-        - error_count: Number of ERROR entries found
-        - warning_count: Number of WARNING entries found
+        - log_text: The (possibly filtered) error log text
+        - error_count: Number of ERROR entries in the filtered output
+        - warning_count: Number of WARNING entries in the filtered output
         - integration_mentions: Map of integration names to mention counts
+        - total_lines: Number of lines in the filtered output
+        - filters_applied: Map of which filter args were supplied
         - error: Error message if retrieval failed
-        
+
     Examples:
-        Returns errors, warnings count and integration mentions
+        get_error_log()                                 # full log
+        get_error_log(level="ERROR")                    # errors only
+        get_error_log(integration="zwave_js")           # one integration
+        get_error_log(search_term="light.kitchen")      # specific entity
+        get_error_log(level="ERROR", lines=50)          # last 50 errors
+
     Best Practices:
-        - Use this tool when troubleshooting specific Home Assistant errors
-        - Look for patterns in repeated errors
-        - Pay attention to timestamps to correlate errors with events
-        - Focus on integrations with many mentions in the log    
+        - Filter on the server side (here) rather than pulling the full
+          log into Claude's context — saves tokens on noisy logs.
+        - Combine `integration` + `level="ERROR"` to triage a single
+          integration that's misbehaving.
+        - Use `lines` to bound output when scanning a long-running HA.
     """
-    logger.info("Getting Home Assistant error log")
-    return await get_hass_error_log()
+    logger.info(
+        "Getting Home Assistant error log "
+        f"(level={level}, integration={integration}, "
+        f"search_term={search_term}, lines={lines})"
+    )
+    return await get_hass_error_log(
+        level=level,
+        integration=integration,
+        search_term=search_term,
+        lines=lines,
+    )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -371,3 +371,159 @@ async def test_get_error_log_falls_back_to_standalone_endpoint():
         assert "\x1b[" not in payload["log_text"], "ANSI codes must be stripped"
         assert payload["error_count"] == 1
         assert payload["integration_mentions"]["light"] == 1
+
+
+# --- Filter tests (#34) -----------------------------------------------------
+
+# Realistic sample log: mix of levels, integrations (bare + namespaced),
+# entity IDs to grep, and enough lines to test `lines` truncation.
+SAMPLE_LOG = (
+    "2026-05-16 12:00:00 INFO (MainThread) [homeassistant.core] starting up\n"
+    "2026-05-16 12:00:01 ERROR (MainThread) [homeassistant.components.mqtt] connection refused\n"
+    "2026-05-16 12:00:02 WARNING (MainThread) [zwave_js] node 5 retrying\n"
+    "2026-05-16 12:00:03 ERROR (MainThread) [homeassistant.components.zwave_js] command timeout on light.kitchen\n"
+    "2026-05-16 12:00:04 INFO (MainThread) [homeassistant.components.light] turning on light.living_room\n"
+    "2026-05-16 12:00:05 ERROR (MainThread) [homeassistant.components.mqtt] reconnect failed\n"
+    "2026-05-16 12:00:06 WARNING (MainThread) [homeassistant.components.light] light.kitchen unavailable\n"
+)
+
+
+def _mock_hassio_log(text: str = SAMPLE_LOG):
+    respx.get("http://localhost:8123/api/hassio/core/logs").mock(
+        return_value=httpx.Response(200, text=text)
+    )
+
+
+@respx.mock
+async def test_get_error_log_filter_by_level():
+    """level=ERROR keeps only ERROR lines and recomputes counts."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log", arguments={"level": "ERROR"}
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["error_count"] == 3
+        assert payload["warning_count"] == 0
+        assert payload["total_lines"] == 3
+        assert "WARNING" not in payload["log_text"]
+        assert "INFO" not in payload["log_text"]
+        assert payload["filters_applied"] == {"level": "ERROR"}
+
+
+@respx.mock
+async def test_get_error_log_filter_by_integration_namespaced():
+    """integration=mqtt matches [homeassistant.components.mqtt]."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log", arguments={"integration": "mqtt"}
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["total_lines"] == 2
+        assert payload["error_count"] == 2
+        assert "zwave" not in payload["log_text"].lower()
+
+
+@respx.mock
+async def test_get_error_log_filter_by_integration_bare():
+    """integration=zwave_js also matches the bare `[zwave_js]` form."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log", arguments={"integration": "zwave_js"}
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        # Both `[zwave_js]` (bare) and `[homeassistant.components.zwave_js]`.
+        assert payload["total_lines"] == 2
+
+
+@respx.mock
+async def test_get_error_log_filter_by_search_term():
+    """search_term matches a substring, case-insensitive."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log", arguments={"search_term": "light.kitchen"}
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["total_lines"] == 2
+        assert all(
+            "light.kitchen" in line.lower()
+            for line in payload["log_text"].splitlines()
+        )
+
+
+@respx.mock
+async def test_get_error_log_filter_by_lines_returns_tail():
+    """lines=N returns only the last N lines after other filters."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log", arguments={"lines": 2}
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["total_lines"] == 2
+        # The last two lines of SAMPLE_LOG.
+        assert "reconnect failed" in payload["log_text"]
+        assert "light.kitchen unavailable" in payload["log_text"]
+
+
+@respx.mock
+async def test_get_error_log_filters_combine_and_stats_match_filtered():
+    """Combined filters AND together; stats are computed over filtered text."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool(
+            "get_error_log",
+            arguments={"level": "ERROR", "integration": "mqtt"},
+        )
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["total_lines"] == 2
+        assert payload["error_count"] == 2
+        # integration_mentions should reflect mqtt-only output.
+        assert payload["integration_mentions"].get("mqtt") == 2
+        assert "zwave_js" not in payload["integration_mentions"]
+        assert payload["filters_applied"] == {
+            "level": "ERROR",
+            "integration": "mqtt",
+        }
+
+
+@respx.mock
+async def test_get_error_log_no_filters_applied_field_empty():
+    """With no filters, filters_applied is an empty dict (not missing)."""
+    import json
+    _mock_hassio_log()
+    async with create_connected_server_and_client_session(
+        mcp._mcp_server, raise_exceptions=True
+    ) as client:
+        result = await client.call_tool("get_error_log", arguments={})
+        assert not result.isError
+        payload = json.loads(result.content[0].text)
+        assert payload["filters_applied"] == {}
+        assert payload["total_lines"] == 7


### PR DESCRIPTION
## Summary

Adds optional filter parameters to `get_error_log` so noisy Home Assistant logs don't blow Claude's context window. Filtering happens server-side, after ANSI stripping, and **stats are recomputed over the filtered output** so `error_count`, `warning_count`, `integration_mentions`, and `total_lines` always match what's returned.

New params (all optional, all combine with AND):

- `level` — keep lines containing this log level (`ERROR`, `WARNING`, `INFO`, `DEBUG`). Case-insensitive.
- `integration` — match `[name]` or `[homeassistant.components.name]`. Case-insensitive.
- `search_term` — case-insensitive substring filter per line (useful for entity IDs / exception names).
- `lines` — return only the last N lines, applied after other filters.

Response also gains a `filters_applied` map showing which filters were active.

Supersedes #34 — ported fresh against current master with thanks to @cstosgale for the original implementation.

## Why not just merge #34?

#34 was opened against a much older tree (pre-0.2.0). Merging it as-is would have:
- Conflicted with the new HA-OS / standalone endpoint fallback in `get_hass_error_log` (#37).
- Missed the lean response / token-efficiency conventions added since.
- Skipped the protocol-level test harness (`tests/test_protocol.py`) added in 0.2.0.

This PR keeps the original idea and credits @cstosgale via `Co-Authored-By`.

## Test plan

- [x] `uv run pytest tests/` — 43 tests pass (was 36).
- [x] 7 new protocol-level tests in `tests/test_protocol.py` cover: level filter, integration filter (namespaced + bare forms), search_term, lines tail, combined filters with stats recomputed over the filtered output, and the empty `filters_applied` case.
- [x] CHANGELOG `[Unreleased]` entry added with link to #34.
- [x] README updated (tool list + usage examples).