### PR TITLE
docs(changelog): 0.5.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-17
+
 ### Added
 - Long-term statistics + date-range history tools. `get_statistics` /
   `get_statistics_range` hit HA's `recorder/statistics_during_period`
@@ -137,7 +139,8 @@ functional changes.
 
 Initial PyPI release.
 
-[Unreleased]: https://github.com/voska/hass-mcp/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/voska/hass-mcp/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/voska/hass-mcp/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/voska/hass-mcp/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/voska/hass-mcp/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/voska/hass-mcp/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
Stamps the [Unreleased] section as 0.5.0. Two notable features land in this release:

- **Long-term statistics + date-range history** (#59, supersedes #30) — new WebSocket client and three tools for querying HA's recorder over arbitrary windows.
- **Error log filtering** (#58, supersedes #34) — `get_error_log` accepts `level`, `integration`, `search_term`, `lines` filters with stats recomputed over the filtered output.

No breaking changes. Merge this, then tag `v0.5.0` to trigger the release pipeline.